### PR TITLE
a minor bug about flipped color for writing point cloud to PCD files

### DIFF
--- a/src/IO/FileFormat/FilePCD.cpp
+++ b/src/IO/FileFormat/FilePCD.cpp
@@ -632,9 +632,9 @@ bool WritePCDHeader(FILE *file, const PCDHeader &header)
 float ConvertRGBToFloat(const Eigen::Vector3d &color)
 {
 	std::uint8_t rgba[4] = {0, 0, 0, 0};
-	rgba[0] = (std::uint8_t)std::max(std::min((int)(color(0) * 255.0), 255), 0);
+	rgba[2] = (std::uint8_t)std::max(std::min((int)(color(0) * 255.0), 255), 0);
 	rgba[1] = (std::uint8_t)std::max(std::min((int)(color(1) * 255.0), 255), 0);
-	rgba[2] = (std::uint8_t)std::max(std::min((int)(color(2) * 255.0), 255), 0);
+	rgba[0] = (std::uint8_t)std::max(std::min((int)(color(2) * 255.0), 255), 0);
 	float value;
 	memcpy(&value, rgba, 4);
 	return value;


### PR DESCRIPTION
Hi Authors,

Similar to #208 , there is a tiny bug for writing point cloud to **PCD** files. When I used `write_point_cloud("./somename.pcd", pcd )` or `write_point_cloud("./somename.pcd", pcd ,write_ascii = True)` , it generated a **PCD** file with flipped color (RGB to BGR).  

So I modified `ConvertRGBToFloat()` function in [Open3D/src/IO/FileFormat/FilePCD.cpp](https://github.com/IntelVCL/Open3D/blob/a51b3fa238f174b43106c8bf3a4970cab28ed6e0/src/IO/FileFormat/FilePCD.cpp#L632) file, and rebuilt it. Now it works good. 

Thanks.