### PR TITLE
Exclude VS2017+CPP14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,8 @@ matrix:
   exclude:
     - image: Visual Studio 2015
       CPP: latest
+    - image: Visual Studio 2017
+      CPP: 14
 install:
 - ps: |
     if ($env:PLATFORM -eq "x64") { $env:CMAKE_ARCH = "x64" }


### PR DESCRIPTION
AppVeyor takes about 40mins for each commit in PR. 
This will exclude VS2017+CPP14 configuration to save some time.

As of today, CI configurations for Windows are following
- VS2015 + CPP14
- VS2017 + CPP newest