### PR TITLE
Fix information matrix bug

### DIFF
--- a/src/Core/Odometry/Odometry.cpp
+++ b/src/Core/Odometry/Odometry.cpp
@@ -270,19 +270,19 @@ Eigen::Matrix6d CreateInfomationMatrix(
             double y = *PointerAt<float>(*xyz_t, u_t, v_t, 1);
             double z = *PointerAt<float>(*xyz_t, u_t, v_t, 2);
             G_r_private.setZero();
-            G_r_private(0) = 1.0;
-            G_r_private(4) = 2.0 * z;
-            G_r_private(5) = -2.0 * y;
+            G_r_private(1) = z;
+            G_r_private(2) = -y;
+            G_r_private(3) = 1.0;
             GTG_private.noalias() += G_r_private * G_r_private.transpose();
             G_r_private.setZero();
-            G_r_private(1) = 1.0;
-            G_r_private(3) = -2.0 * z;
-            G_r_private(5) = 2.0 * x;
+            G_r_private(0) = -z;
+            G_r_private(2) = x;
+            G_r_private(4) = 1.0;
             GTG_private.noalias() += G_r_private * G_r_private.transpose();
             G_r_private.setZero();
-            G_r_private(2) = 1.0;
-            G_r_private(3) = 2.0 * y;
-            G_r_private(4) = -2.0 * x;
+            G_r_private(0) = y;
+            G_r_private(1) = -x;
+            G_r_private(5) = 1.0;
             GTG_private.noalias() += G_r_private * G_r_private.transpose();
         }
 #ifdef _OPENMP

--- a/src/Core/Registration/Registration.cpp
+++ b/src/Core/Registration/Registration.cpp
@@ -377,19 +377,19 @@ Eigen::Matrix6d GetInformationMatrixFromPointClouds(
             double y = target.points_[t](1);
             double z = target.points_[t](2);
             G_r_private.setZero();
-            G_r_private(0) = 1.0;
-            G_r_private(4) = z;
-            G_r_private(5) = -y;
+            G_r_private(1) = z;
+            G_r_private(2) = -y;
+            G_r_private(3) = 1.0;
             GTG_private.noalias() += G_r_private * G_r_private.transpose();
             G_r_private.setZero();
-            G_r_private(1) = 1.0;
-            G_r_private(3) = -z;
-            G_r_private(5) = x;
+            G_r_private(0) = -z;
+            G_r_private(2) = x;
+            G_r_private(4) = 1.0;
             GTG_private.noalias() += G_r_private * G_r_private.transpose();
             G_r_private.setZero();
-            G_r_private(2) = 1.0;
-            G_r_private(3) = y;
-            G_r_private(4) = -x;
+            G_r_private(0) = y;
+            G_r_private(1) = -x;
+            G_r_private(5) = 1.0;
             GTG_private.noalias() += G_r_private * G_r_private.transpose();
         }
 #ifdef _OPENMP


### PR DESCRIPTION
- Information matrix in Odometry.cpp had '2.0' coefficient that came from legacy code used for g2o interface. g2o takes quatanion, so '2.0' were added for that. Removed now.
- Information matrix should be made based on [-q_x | I ] as shown in http://redwood-data.org/indoor/registration.html, but it wasn't configured in that way. Ordering coefficients accordingly.
- I validated this fix using Reconstruction System, and found improved result. Related to #287.
