### PR TITLE
saving open3d.cp36-win_amd64.pyd in appveyor artefacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -50,3 +50,6 @@ build_script:
 - cmake --build . --config %CONFIG% --target INSTALL
 # The following script has issues on SHARED = "ON"
 # - cd lib/Release/Tutorial/Basic && python file_io.py
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+- path:  build\lib\Release\open3d.cp36-win_amd64.pyd


### PR DESCRIPTION
saving open3d.cp36-win_amd64.pyd in appveyor artefacts so that one get the possibility to install the python binding to open3D on windows by simply downloading it from appveyor and copying into his python36/Lib/site-packages folder. Example here https://ci.appveyor.com/project/martinResearch/open3d/build/1.0.13/job/k94ocafr8tn0x4m9/artifacts