### PR TITLE
Fix MacOS libpng linking issue

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,6 +185,7 @@ include_directories(${GLFW_INCLUDE_DIRS})
 include_directories(${JSONCPP_INCLUDE_DIRS})
 link_directories(${GLFW_LIBRARY_DIRS})
 link_directories(${JSONCPP_LIBRARY_DIRS})
+link_directories(${PNG_LIBRARY_DIRS})
 include_directories(${PROJECT_SOURCE_DIR})
 
 # Open3D libraries


### PR DESCRIPTION
### Fixes #391

Before (with `make VERBOSE=1`), reproducing #391:
```
[ 68%] Linking CXX executable ../bin/MergeMesh
cd /Users/ylao/repo/Open3D/build/Tools && /usr/local/Cellar/cmake/3.9.1/bin/cmake -E cmake_link_script CMakeFiles/MergeMesh.dir/link.txt --verbose=1
/usr/local/bin/c++   -std=c++11 -O3 -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/MergeMesh.dir/MergeMesh.cpp.o  -o ../bin/MergeMesh  -L/usr/local/Cellar/jsoncpp/1.8.4/lib -Wl,-rpath,/usr/local/Cellar/jsoncpp/1.8.4/lib ../lib/libOpen3D.a -framework OpenGL ../lib/libglfw3.a -framework Cocoa -framework IOKit -framework CoreFoundation -framework CoreVideo ../lib/libglew.a ../lib/libjpeg.a -ljsoncpp -lpng16 -lz ../lib/libtinyfiledialogs.a
ld: library not found for -lpng16
```

After:
```
[100%] Linking CXX executable ../bin/MergeMesh
cd /Users/ylao/repo/Open3D/build/Tools && /usr/local/Cellar/cmake/3.9.1/bin/cmake -E cmake_link_script CMakeFiles/MergeMesh.dir/link.txt --verbose=1
/usr/local/bin/c++   -std=c++11 -O3 -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/MergeMesh.dir/MergeMesh.cpp.o  -o ../bin/MergeMesh  -L/usr/local/Cellar/jsoncpp/1.8.4/lib  -L/usr/local/Cellar/libpng/1.6.34/lib -Wl,-rpath,/usr/local/Cellar/jsoncpp/1.8.4/lib -Wl,-rpath,/usr/local/Cellar/libpng/1.6.34/lib ../lib/libOpen3D.a -framework OpenGL ../lib/libglfw3.a -framework Cocoa -framework IOKit -framework CoreFoundation -framework CoreVideo ../lib/libglew.a ../lib/libjpeg.a -ljsoncpp -lpng16 -lz ../lib/libtinyfiledialogs.a
```

Notice that  `-L/usr/local/Cellar/libpng/1.6.34/lib` is added to the linking command above.

### Environments
Tested on
```
MacOS: High Sierra 10.13.3 (17D102)
Cmake: 3.9.1
CC: Apple LLVM version 9.1.0 (clang-902.0.39.2)
libpng: 1.6.34, installed by `brew`
```

`PNG_LIBRARY_DIRS` is set by one of the helper macros in [FindPNG.cmake](https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindPNG.cmake). 

In my system,
```
message("PNG_LIBRARY_DIRS: ${PNG_LIBRARY_DIRS}")
```
outputs
```
PNG_LIBRARY_DIRS: /usr/local/Cellar/libpng/1.6.34/lib
```