### PR TITLE
 Supporting interactive cropping of meshes

### DIFF
--- a/src/Core/Geometry/DownSample.cpp
+++ b/src/Core/Geometry/DownSample.cpp
@@ -253,4 +253,24 @@ std::shared_ptr<PointCloud> CropPointCloud(const PointCloud &input,
     return SelectDownSample(input, indices);
 }
 
+std::shared_ptr<TriangleMesh> CropTriangleMesh(const TriangleMesh &input,
+        const Eigen::Vector3d &min_bound, const Eigen::Vector3d &max_bound)
+{
+    if (min_bound(0) > max_bound(0) || min_bound(1) > max_bound(1) ||
+            min_bound(2) > max_bound(2)) {
+        PrintDebug("[CropTriangleMesh] Illegal boundary clipped all points.\n");
+        return std::make_shared<TriangleMesh>();
+    }
+    std::vector<size_t> indices;
+    for (size_t i = 0; i < input.vertices_.size(); i++) {
+        const auto &point = input.vertices_[i];
+        if (point(0) >= min_bound(0) && point(0) <= max_bound(0) &&
+                point(1) >= min_bound(1) && point(1) <= max_bound(1) &&
+                point(2) >= min_bound(2) && point(2) <= max_bound(2)) {
+            indices.push_back(i);
+        }
+    }
+    return SelectDownSample(input, indices);
+}
+
 }    // namespace three

--- a/src/Core/Geometry/TriangleMesh.h
+++ b/src/Core/Geometry/TriangleMesh.h
@@ -126,6 +126,12 @@ public:
 std::shared_ptr<TriangleMesh> SelectDownSample(const TriangleMesh &input,
         const std::vector<size_t> &indices);
 
+/// Function to crop \param input tringlemesh into output tringlemesh
+/// All points with coordinates less than \param min_bound or larger than
+/// \param max_bound are clipped.
+std::shared_ptr<TriangleMesh> CropTriangleMesh(const TriangleMesh &input,
+        const Eigen::Vector3d &min_bound, const Eigen::Vector3d &max_bound);
+
 /// Factory function to create a sphere mesh (TriangleMeshFactory.cpp)
 /// The sphere with \param radius will be centered at (0, 0, 0).
 /// Its axis is aligned with z-axis.

--- a/src/Core/Geometry/TriangleMesh.h
+++ b/src/Core/Geometry/TriangleMesh.h
@@ -120,6 +120,12 @@ public:
     std::vector<Eigen::Vector3d> triangle_normals_;
 };
 
+/// Function to select points from \param input pointcloud into
+/// \return output pointcloud
+/// Points with indices in \param indices are selected.
+std::shared_ptr<TriangleMesh> SelectDownSample(const TriangleMesh &input,
+        const std::vector<size_t> &indices);
+
 /// Factory function to create a sphere mesh (TriangleMeshFactory.cpp)
 /// The sphere with \param radius will be centered at (0, 0, 0).
 /// Its axis is aligned with z-axis.

--- a/src/Core/Geometry/TriangleMesh.h
+++ b/src/Core/Geometry/TriangleMesh.h
@@ -120,9 +120,9 @@ public:
     std::vector<Eigen::Vector3d> triangle_normals_;
 };
 
-/// Function to select points from \param input pointcloud into
-/// \return output pointcloud
-/// Points with indices in \param indices are selected.
+/// Function to select points from \param input TriangleMesh into
+/// \return output TriangleMesh
+/// Vertices with indices in \param indices are selected.
 std::shared_ptr<TriangleMesh> SelectDownSample(const TriangleMesh &input,
         const std::vector<size_t> &indices);
 

--- a/src/Python/Core/open3d_trianglemesh.cpp
+++ b/src/Python/Core/open3d_trianglemesh.cpp
@@ -80,6 +80,12 @@ void pybind_trianglemesh_methods(py::module &m)
         return WriteTriangleMesh(filename, mesh, write_ascii, compressed);
     }, "Function to write TriangleMesh to file", "filename"_a, "mesh"_a,
             "write_ascii"_a = false, "compressed"_a = false);
+    m.def("select_down_sample", &SelectDownSample,
+            "Function to select mesh from input triangle mesh into output triangle mesh",
+            "input"_a, "indices"_a);
+    m.def("crop_triangle_mesh", &CropTriangleMesh,
+            "Function to crop input triangle mesh into output triangle mesh",
+            "input"_a, "min_bound"_a, "max_bound"_a);
     m.def("create_mesh_sphere", &CreateMeshSphere,
             "Factory function to create a sphere mesh",
             "radius"_a = 1.0, "resolution"_a = 20);

--- a/src/Tools/CMakeLists.txt
+++ b/src/Tools/CMakeLists.txt
@@ -13,6 +13,6 @@ endmacro(TOOL)
 
 TOOL(ConvertPointCloud      ${CMAKE_PROJECT_NAME})
 TOOL(EncodeShader)
-TOOL(ManuallyCropPointCloud ${CMAKE_PROJECT_NAME})
+TOOL(ManuallyCropGeometry   ${CMAKE_PROJECT_NAME})
 TOOL(MergeMesh              ${CMAKE_PROJECT_NAME})
 TOOL(ViewGeometry           ${CMAKE_PROJECT_NAME})

--- a/src/Visualization/Utility/SelectionPolygon.cpp
+++ b/src/Visualization/Utility/SelectionPolygon.cpp
@@ -27,6 +27,7 @@
 #include "SelectionPolygon.h"
 
 #include <Core/Geometry/PointCloud.h>
+#include <Core/Geometry/TriangleMesh.h>
 #include <Core/Utility/Console.h>
 #include <Visualization/Visualizer/ViewControl.h>
 #include <Visualization/Visualizer/ViewControlWithEditing.h>
@@ -127,6 +128,23 @@ std::shared_ptr<PointCloud> SelectionPolygon::CropPointCloud(
     }
 }
 
+std::shared_ptr<TriangleMesh> SelectionPolygon::CropTriangleMesh(
+        const TriangleMesh &input, const ViewControl &view)
+{
+    if (IsEmpty()) {
+        return std::make_shared<TriangleMesh>();
+    }
+    switch (polygon_type_) {
+    case SectionPolygonType::Rectangle:
+        return CropTriangleMeshInRectangle(input, view);
+    case SectionPolygonType::Polygon:
+        return CropTriangleMeshInPolygon(input, view);
+    case SectionPolygonType::Unfilled:
+    default:
+        return std::shared_ptr<TriangleMesh>();
+    }
+}
+
 std::shared_ptr<SelectionPolygonVolume> SelectionPolygon::
         CreateSelectionPolygonVolume(const ViewControl &view)
 {
@@ -180,6 +198,18 @@ std::shared_ptr<PointCloud> SelectionPolygon::CropPointCloudInPolygon(
         const PointCloud &input, const ViewControl &view)
 {
     return SelectDownSample(input, CropInPolygon(input.points_, view));
+}
+
+std::shared_ptr<TriangleMesh> SelectionPolygon::CropTriangleMeshInRectangle(
+        const TriangleMesh &input, const ViewControl &view)
+{
+    return SelectDownSample(input, CropInRectangle(input.vertices_, view));
+}
+
+std::shared_ptr<TriangleMesh> SelectionPolygon::CropTriangleMeshInPolygon(
+        const TriangleMesh &input, const ViewControl &view)
+{
+    return SelectDownSample(input, CropInPolygon(input.vertices_, view));
 }
 
 std::vector<size_t> SelectionPolygon::CropInRectangle(

--- a/src/Visualization/Utility/SelectionPolygon.h
+++ b/src/Visualization/Utility/SelectionPolygon.h
@@ -35,6 +35,7 @@
 namespace three {
 
 class PointCloud;
+class TriangleMesh;
 class ViewControl;
 class SelectionPolygonVolume;
 
@@ -63,6 +64,8 @@ public:
     void FillPolygon(int width, int height);
     std::shared_ptr<PointCloud> CropPointCloud(
             const PointCloud &input, const ViewControl &view);
+    std::shared_ptr<TriangleMesh> CropTriangleMesh(
+            const TriangleMesh &input, const ViewControl &view);
     std::shared_ptr<SelectionPolygonVolume> CreateSelectionPolygonVolume(
             const ViewControl &view);
 
@@ -71,6 +74,10 @@ private:
             const PointCloud &input, const ViewControl &view);
     std::shared_ptr<PointCloud> CropPointCloudInPolygon(
             const PointCloud &input, const ViewControl &view);
+    std::shared_ptr<TriangleMesh> CropTriangleMeshInRectangle(
+            const TriangleMesh &input, const ViewControl &view);
+    std::shared_ptr<TriangleMesh> CropTriangleMeshInPolygon(
+            const TriangleMesh &input, const ViewControl &view);
     std::vector<size_t> CropInRectangle(
             const std::vector<Eigen::Vector3d> &input, const ViewControl &view);
     std::vector<size_t> CropInPolygon(

--- a/src/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -34,6 +34,7 @@
 #include <Core/Utility/FileSystem.h>
 #include <IO/ClassIO/IJsonConvertibleIO.h>
 #include <IO/ClassIO/PointCloudIO.h>
+#include <IO/ClassIO/TriangleMeshIO.h>
 #include <Visualization/Visualizer/ViewControlWithEditing.h>
 #include <Visualization/Visualizer/RenderOptionWithEditing.h>
 #include <Visualization/Utility/SelectionPolygon.h>
@@ -625,8 +626,13 @@ void VisualizerWithEditing::SaveCroppingResult(
     }
     std::string volume_filename = filesystem::GetFileNameWithoutExtension(
             filename) + ".json";
-    WritePointCloud(ply_filename,
-            (const PointCloud &)(*geometry_ptrs_[0]));
+    if (geometry_ptrs_[0]->GetGeometryType() ==
+            Geometry::GeometryType::PointCloud)
+        WritePointCloud(ply_filename, (const PointCloud &)(*geometry_ptrs_[0]));
+    else if (geometry_ptrs_[0]->GetGeometryType() ==
+            Geometry::GeometryType::TriangleMesh)
+        WriteTriangleMesh(ply_filename,
+                (const TriangleMesh &)(*geometry_ptrs_[0]));
     WriteIJsonConvertible(volume_filename,
             *selection_polygon_ptr_->CreateSelectionPolygonVolume(
             GetViewControl()));

--- a/src/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -392,6 +392,33 @@ void VisualizerWithEditing::KeyPressCallback(GLFWwindow *window,
                 view_control.ToggleLocking();
                 InvalidateSelectionPolygon();
                 InvalidatePicking();
+            } else if (editing_geometry_ptr_ &&
+                    editing_geometry_ptr_->GetGeometryType() ==
+                    Geometry::GeometryType::TriangleMesh) {
+                glfwMakeContextCurrent(window_);
+                TriangleMesh &mesh = (TriangleMesh &)*editing_geometry_ptr_;
+                mesh = *selection_polygon_ptr_->CropTriangleMesh(mesh,
+                        view_control);
+                editing_geometry_renderer_ptr_->UpdateGeometry();
+                const char *filename;
+                const char *pattern[1] = {"*.ply"};
+                std::string default_filename = default_directory_ +
+                        "cropped.ply";
+                if (use_dialog_) {
+                    filename = tinyfd_saveFileDialog("Mesh file",
+                            default_filename.c_str(), 1, pattern,
+                            "Polygon File Format (*.ply)");
+                } else {
+                    filename = default_filename.c_str();
+                }
+                if (filename == NULL) {
+                    PrintInfo("No filename is given. Abort saving.\n");
+                } else {
+                    SaveCroppingResult(filename);
+                }
+                view_control.ToggleLocking();
+                InvalidateSelectionPolygon();
+                InvalidatePicking();
             }
         } else {
             Visualizer::KeyPressCallback(window, key, scancode, action, mods);


### PR DESCRIPTION
VisualizerWithEditing class supports interactive cropping of meshes. 
- Adding SelectDownSample function for Triangular mesh
Keep a triangle only if all the three corresponding vertices are selected by user.
Preserves vertex ordering
- Generalize Tools/ManuallyCropPointCloud to Tools/ManuallyCropGeometry
Either point cloud and mesh is supported.

**Example of mesh cropping**:
```
./ManuallyCropGeometry --mesh [path_to_mesh_file] 
```
<img width="536" alt="mesh" src="https://user-images.githubusercontent.com/18297113/42001691-9b56edfc-7a19-11e8-9b70-e8b3b6742575.png">
<img width="536" alt="mesh_crop" src="https://user-images.githubusercontent.com/18297113/42001692-9b708aaa-7a19-11e8-84e7-d2dbaf2d0a69.png">

**Example of point cloud cropping**:
```
./ManuallyCropGeometry --pointcloud [path_to_mesh_or_pointcloud_file] 
```
<img width="536" alt="pointcloud" src="https://user-images.githubusercontent.com/18297113/42001693-9b8c3188-7a19-11e8-84fd-cf7abeb757a0.png">
<img width="536" alt="pointcloud_crop" src="https://user-images.githubusercontent.com/18297113/42001694-9ba3e012-7a19-11e8-9551-38ce824098ea.png">

