### PR TITLE
Point to plane ICP error message

### DIFF
--- a/src/Core/Registration/ColoredICP.cpp
+++ b/src/Core/Registration/ColoredICP.cpp
@@ -46,6 +46,8 @@ public:
 
 class TransformationEstimationForColoredICP : public TransformationEstimation {
 public:
+    TransformationEstimationType GetTransformationEstimationType()
+            const override { return type_; };
     TransformationEstimationForColoredICP(
             double lambda_geometric = 0.968) :
             lambda_geometric_(lambda_geometric) {
@@ -63,6 +65,8 @@ public:
 
 public:
     double lambda_geometric_;
+    const TransformationEstimationType type_ =
+            TransformationEstimationType::ColoredICP;
 };
 
 std::shared_ptr<PointCloudForColoredICP>

--- a/src/Core/Registration/ColoredICP.cpp
+++ b/src/Core/Registration/ColoredICP.cpp
@@ -65,6 +65,8 @@ public:
 
 public:
     double lambda_geometric_;
+
+private:
     const TransformationEstimationType type_ =
             TransformationEstimationType::ColoredICP;
 };

--- a/src/Core/Registration/Registration.cpp
+++ b/src/Core/Registration/Registration.cpp
@@ -146,8 +146,16 @@ RegistrationResult RegistrationICP(const PointCloud &source,
         const ICPConvergenceCriteria &criteria/* = ICPConvergenceCriteria()*/)
 {
     if (max_correspondence_distance <= 0.0) {
+        PrintError("Error: Invalid max_correspondence_distance.\n");
         return RegistrationResult(init);
     }
+    if (estimation.GetTransformationEstimationType() ==
+            TransformationEstimationType::PointToPlane &&
+            (!source.HasNormals() || !target.HasNormals())) {
+        PrintError("Error: TransformationEstimationPointToPlane requires pre-computed normal vectors.\n");
+        return RegistrationResult(init);
+    }
+
     Eigen::Matrix4d transformation = init;
     KDTreeFlann kdtree;
     kdtree.SetGeometry(target);

--- a/src/Core/Registration/TransformationEstimation.h
+++ b/src/Core/Registration/TransformationEstimation.h
@@ -37,6 +37,14 @@ class PointCloud;
 
 typedef std::vector<Eigen::Vector2i> CorrespondenceSet;
 
+enum class TransformationEstimationType
+{
+    Unspecified = 0,
+    PointToPoint = 1,
+    PointToPlane = 2,
+    ColoredICP = 3,
+};
+
 /// Base class that estimates a transformation between two point clouds
 /// The virtual function ComputeTransformation() must be implemented in
 /// subclasses.
@@ -47,6 +55,8 @@ public:
     virtual ~TransformationEstimation() {}
 
 public:
+    virtual TransformationEstimationType
+            GetTransformationEstimationType() const = 0;
     virtual double ComputeRMSE(const PointCloud &source,
             const PointCloud &target,
             const CorrespondenceSet &corres) const = 0;
@@ -64,6 +74,8 @@ public:
     ~TransformationEstimationPointToPoint() override {}
 
 public:
+    TransformationEstimationType GetTransformationEstimationType()
+            const override { return type_; };
     double ComputeRMSE(const PointCloud &source, const PointCloud &target,
             const CorrespondenceSet &corres) const override;
     Eigen::Matrix4d ComputeTransformation(const PointCloud &source,
@@ -72,6 +84,8 @@ public:
 
 public:
     bool with_scaling_ = false;
+    const TransformationEstimationType type_ =
+            TransformationEstimationType::PointToPoint;
 };
 
 /// Estimate a transformation for point to plane distance
@@ -82,11 +96,17 @@ public:
     ~TransformationEstimationPointToPlane() override {}
 
 public:
+    TransformationEstimationType GetTransformationEstimationType()
+            const override { return type_; };
     double ComputeRMSE(const PointCloud &source, const PointCloud &target,
             const CorrespondenceSet &corres) const override;
     Eigen::Matrix4d ComputeTransformation(const PointCloud &source,
             const PointCloud &target,
             const CorrespondenceSet &corres) const override;
+
+public:
+    const TransformationEstimationType type_ =
+            TransformationEstimationType::PointToPlane;
 };
 
 

--- a/src/Core/Registration/TransformationEstimation.h
+++ b/src/Core/Registration/TransformationEstimation.h
@@ -84,6 +84,8 @@ public:
 
 public:
     bool with_scaling_ = false;
+
+private:
     const TransformationEstimationType type_ =
             TransformationEstimationType::PointToPoint;
 };
@@ -104,7 +106,7 @@ public:
             const PointCloud &target,
             const CorrespondenceSet &corres) const override;
 
-public:
+private:
     const TransformationEstimationType type_ =
             TransformationEstimationType::PointToPlane;
 };

--- a/src/Python/Core/open3d_registration.cpp
+++ b/src/Python/Core/open3d_registration.cpp
@@ -42,6 +42,11 @@ class PyTransformationEstimation : public TransformationEstimationBase
 {
 public:
     using TransformationEstimationBase::TransformationEstimationBase;
+    TransformationEstimationType GetTransformationEstimationType()
+            const override {
+        PYBIND11_OVERLOAD_PURE(TransformationEstimationType,
+                TransformationEstimationBase, void);
+    }
     double ComputeRMSE(const PointCloud &source, const PointCloud &target,
             const CorrespondenceSet &corres) const override {
         PYBIND11_OVERLOAD_PURE(double, TransformationEstimationBase,


### PR DESCRIPTION
This PR related to #411.

Key changes:
- Define TransformationEstimationType
- Adding TransformationEstimationType variable in TransformationEstimation class
- RegistrationICP terminates early with error message like below if there is no normal direction is given
```
Error: TransformationEstimationPointToPlane requires pre-computed normal vectors.
```