### PR TITLE
Sort the file list with Alphanumeric order.

### DIFF
--- a/src/Python/Tutorial/Utility/common.py
+++ b/src/Python/Tutorial/Utility/common.py
@@ -3,6 +3,7 @@
 # See license file or visit www.open3d.org for details
 
 import copy
+import re
 from open3d import *
 from os import listdir, makedirs
 from os.path import exists, isfile, join, splitext
@@ -31,13 +32,19 @@ template_global_posegraph_optimized = folder_scene + \
 template_global_mesh = folder_scene + "integrated.ply"
 
 
+def sorted_alphanum(file_list_unorderd):
+    convert = lambda text: int(text) if text.isdigit() else text
+    alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
+    return sorted(file_list_unorderd, key=alphanum_key)
+
+
 def get_file_list(path, extension=None):
     if extension is None:
         file_list = [path + f for f in listdir(path) if isfile(join(path, f))]
     else:
         file_list = [path + f for f in listdir(path)
                 if isfile(join(path, f)) and splitext(f)[1] == extension]
-    file_list.sort()
+    file_list = sorted_alphanum(file_list)
     return file_list
 
 

--- a/src/Python/Tutorial/Utility/common.py
+++ b/src/Python/Tutorial/Utility/common.py
@@ -32,10 +32,10 @@ template_global_posegraph_optimized = folder_scene + \
 template_global_mesh = folder_scene + "integrated.ply"
 
 
-def sorted_alphanum(file_list_unorderd):
+def sorted_alphanum(file_list_ordered):
     convert = lambda text: int(text) if text.isdigit() else text
     alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
-    return sorted(file_list_unorderd, key=alphanum_key)
+    return sorted(file_list_ordered, key=alphanum_key)
 
 
 def get_file_list(path, extension=None):


### PR DESCRIPTION
@syncle This PR is to solve to the issue mentioned in #231 when using the reconstruction tutorial. The added lines will sort the files list in Alphanumeric order compared to the sorted native function in Python. 