### PR TITLE
Orient normals based on MST

### DIFF
--- a/src/Core/Geometry/PointCloud.h
+++ b/src/Core/Geometry/PointCloud.h
@@ -146,6 +146,13 @@ bool EstimateNormals(PointCloud &cloud,
         const KDTreeSearchParam &search_param = KDTreeSearchParamKNN());
 
 /// Function to orient the normals of a point cloud
+/// \param cloud is the input point cloud. It must have normals and points.
+/// Surface is assumed to consist of a single connected component
+/// \param search_param The KDTree search parameters
+bool OrientNormalsUsingMST(PointCloud &cloud,
+        const KDTreeSearchParam &search_param = KDTreeSearchParamKNN());
+
+/// Function to orient the normals of a point cloud
 /// \param cloud is the input point cloud. It must have normals.
 /// Normals are oriented with respect to \param orientation_reference
 bool OrientNormalsToAlignWithDirection(PointCloud &cloud,

--- a/src/UnitTest/Core/Geometry/EstimateNormals.cpp
+++ b/src/UnitTest/Core/Geometry/EstimateNormals.cpp
@@ -25,8 +25,68 @@
 // ----------------------------------------------------------------------------
 
 #include "UnitTest.h"
+#include "../Core/Geometry/PointCloud.h"
+#include <random>
+#include <Eigen/Geometry>
+
+using namespace three;
 
 TEST(EstimateNormals, Default)
 {
     NotImplemented();
+}
+
+TEST(EstimateNormals, OrientNormalsUsingMST)
+{
+    std::default_random_engine gen(0);
+    std::uniform_int_distribution<int> u(0,1);
+    auto sample = [&u,&gen]() { return (u(gen) ? -1 : 1); };
+
+    // Test planar surfaces
+    PointCloud plane_xy;
+    for(int y = 0; y < 10; ++y) {
+        for(int x = 0; x < 20; ++x) {
+            plane_xy.points_.emplace_back(x, y, 0);
+            plane_xy.normals_.emplace_back(0, 0, sample());
+        }
+    }
+    Eigen::Vector3d axis = Eigen::Vector3d::Random();
+    auto T_rand = Eigen::Translation3d(Eigen::Vector3d::Random()) *
+                  Eigen::AngleAxisd(axis.norm(), axis/axis.norm());
+    auto plane_rand = plane_xy;
+    plane_rand.Transform(T_rand.matrix());
+
+    ASSERT_TRUE(OrientNormalsUsingMST(plane_xy));
+    ASSERT_TRUE(OrientNormalsUsingMST(plane_rand));
+
+    const auto& n_ref_xy = plane_xy.normals_[0];
+    for(const auto& n : plane_xy.normals_) {
+        EXPECT_NEAR(n_ref_xy.dot(n), 1.0, 1e-7);
+    }
+
+    const auto& n_ref_rand = plane_rand.normals_[0];
+    for(const auto& n : plane_rand.normals_) {
+        EXPECT_NEAR(n_ref_rand.dot(n), 1.0, 1e-7);
+    }
+
+    // Test sphere surface
+    PointCloud sphere;
+    constexpr double r = 1.0;
+    for(int i_az = 0; i_az < 360; i_az = i_az + 30) {
+        for(int i_elev = -89; i_elev <= 89; i_elev = i_elev + 30) {
+            double az = i_az*M_PI/180.0;
+            double elev = i_elev*M_PI/180.0;
+            Eigen::Vector3d n(cos(elev)*cos(az), cos(elev)*sin(az), sin(elev));
+            sphere.points_.emplace_back(r*n[0], r*n[1], r*n[2]);
+            sphere.normals_.emplace_back(n*sample());
+        }
+    }
+    if(sphere.points_[0].dot(sphere.normals_[0]) < 0) {
+        sphere.normals_[0] *= -1.0;
+    }
+    ASSERT_TRUE(OrientNormalsUsingMST(sphere));
+
+    for(int i =0; i < sphere.points_.size(); ++i) {
+        EXPECT_TRUE(sphere.points_[i].dot(sphere.normals_[i]) > 0);
+    }
 }


### PR DESCRIPTION
@germanros1987 I have added an algorithm and its unit test to orient normals using a MST as requested in https://github.com/IntelVCL/Open3D/issues/270.

Note that given an intial point to create a MST that connects the point cloud passed as input, KNN can  just connect a subset of the original points invalidating the assumption in section 3.3 in http://hhoppe.com/recon.pdf, i.e., "the surface is assumed to consist of a single connected component".  
