### PR TITLE
Add clang-format file, PR 1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 80
+UseTab: Never
+Language: Cpp
+Standard: Cpp11

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -49,7 +49,7 @@ Consistent coding style is an important factor of code readability. Some princip
 
 We generally follow the `Google C++ Style Guide <https://google.github.io/styleguide/cppguide.html>`_, with a few modifications:
 
-* Use tab for indent. In IDE it should be 4 spaces wide. Use two indents for a forced line break (usually due to the 80 character length limit).
+* Use 4 spaces for indent. Use two indents for a forced line break (usually due to the 80 character length limit).
 * Use ``#pragma once`` for header guard.
 * All Open3D classes and functions are nested in namespace ``open3d``.
 * Avoid using naked pointers. Use ``std::shared_ptr`` and ``std::unique_ptr`` instead.


### PR DESCRIPTION
## Background
Clang-format is widely used in C++ projects such as [this](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/.clang-format), [this](https://github.com/pytorch/pytorch/blob/master/.clang-format) and [this](https://github.com/llvm-mirror/llvm/blob/master/.clang-format). Applying Clang-format to the Open3D code base could automatically ensure our code have consistent styling, and avoid manual formatting such as in https://github.com/IntelVCL/Open3D/pull/478. 

Clang format works by first having a `.clang-format` file defining the desired style in the root folder, and then running the `clang-format` command to the targeted files, such as `clang-format -i my_file.cpp`.

## Implementation
To avoid abrupt changes to the code base, we could make incremental changes:

### PR 1 (this PR): Define format
Define and add `.clang-format` in our root directory.
### PR 2: Add formatting scripts
Add two scripts for 1) checking if all cpp files are compliant, 2) formatting all cpp files. 
### PR 3: Apply format globally & Enable CI
There will be major changes to the code base. We can do this right before or right after a major release to minimize impacts. CI will be enabled so that further PRs will be style-checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/532)
<!-- Reviewable:end -->
