### PR TITLE
exposing some colormap optimization options to python

### DIFF
--- a/src/Python/Core/open3d_colormap.cpp
+++ b/src/Python/Core/open3d_colormap.cpp
@@ -53,6 +53,10 @@ void pybind_colormap_optimization(py::module &m)
          &ColorMapOptmizationOption::maximum_allowable_depth_)
          .def_readwrite("depth_threshold_for_visiblity_check",
          &ColorMapOptmizationOption::depth_threshold_for_visiblity_check_)
+         .def_readwrite("depth_threshold_for_discontinuity_check",
+         &ColorMapOptmizationOption::depth_threshold_for_discontinuity_check_)
+         .def_readwrite("half_dilation_kernel_size_for_discontinuity_map",
+         &ColorMapOptmizationOption::half_dilation_kernel_size_for_discontinuity_map_)
         .def("__repr__", [](const ColorMapOptmizationOption &to) {
             return std::string("ColorMapOptmizationOption with") +
                     std::string("\n- non_rigid_camera_coordinate : ") +
@@ -66,7 +70,11 @@ void pybind_colormap_optimization(py::module &m)
                     std::string("\n- maximum_allowable_depth : ") +
                     std::to_string(to.maximum_allowable_depth_) +
                     std::string("\n- depth_threshold_for_visiblity_check : ") +
-                    std::to_string(to.depth_threshold_for_visiblity_check_);
+                    std::to_string(to.depth_threshold_for_visiblity_check_) +
+                    std::string("\n- depth_threshold_for_discontinuity_check : ") +
+                    std::to_string(to.depth_threshold_for_discontinuity_check_) +
+                    std::string("\n- half_dilation_kernel_size_for_discontinuity_map : ") +
+                    std::to_string(to.half_dilation_kernel_size_for_discontinuity_map_);
         });
 }
 


### PR DESCRIPTION
The `depth_threshold_for_discontinuity_check` and `half_dilation_kernel_size_for_discontinuity_map` from the `ColorMapOptimizationOption` class are now exposed to Python

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/555)
<!-- Reviewable:end -->
