### PR TITLE
fix ENABLE_HEADLESS_RENDERING flag issue

### DIFF
--- a/3rdparty/GLFW/CMakeLists.txt
+++ b/3rdparty/GLFW/CMakeLists.txt
@@ -26,7 +26,7 @@ set(GLFW_INSTALL ON)
 option(GLFW_VULKAN_STATIC "Use the Vulkan loader statically linked into application" OFF)
 
 if (UNIX)
-    if (HEADLESS_RENDERING)
+    if (ENABLE_HEADLESS_RENDERING)
     	set(GLFW_USE_OSMESA ON)
     else ()
         set(GLFW_USE_OSMESA OFF)

--- a/3rdparty/glew/CMakeLists.txt
+++ b/3rdparty/glew/CMakeLists.txt
@@ -3,7 +3,7 @@ project(glew C)
 cmake_minimum_required(VERSION 3.0.0)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 
-if (HEADLESS_RENDERING)
+if (ENABLE_HEADLESS_RENDERING)
 	set(GLEW_OSMESA ON)
 else ()
 	set(GLEW_OSMESA OFF)


### PR DESCRIPTION
This fixes #578.

The issue arise when OPEN3D_HEADLESS_RENDERING were renamed as ENABLE_HEADLESS_RENDERING in [this commit](https://github.com/IntelVCL/Open3D/commit/d843712297606acd2ea53b9479b2c59ba814046c).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/579)
<!-- Reviewable:end -->
