### PR TITLE
Adding CropTriangleMesh to SelectionPolygonVolume and pybindings

### DIFF
--- a/src/Python/Visualization/open3d_utility.cpp
+++ b/src/Python/Visualization/open3d_utility.cpp
@@ -28,6 +28,7 @@
 
 #include <Core/Utility/FileSystem.h>
 #include <Core/Geometry/PointCloud.h>
+#include <Core/Geometry/TriangleMesh.h>
 #include <Visualization/Utility/SelectionPolygonVolume.h>
 #include <Visualization/Utility/DrawGeometry.h>
 #include <Visualization/Visualizer/Visualizer.h>
@@ -45,6 +46,10 @@ void pybind_utility(py::module &m)
         .def("crop_point_cloud", [](const SelectionPolygonVolume &s,
                 const PointCloud &input) {
             return s.CropPointCloud(input);
+        }, "input"_a)
+        .def("crop_triangle_mesh", [](const SelectionPolygonVolume &s,
+                const TriangleMesh &input) {
+            return s.CropTriangleMesh(input);
         }, "input"_a)
         .def("__repr__", [](const SelectionPolygonVolume &s) {
             return std::string("SelectionPolygonVolume, access its members:\n"

--- a/src/Visualization/Utility/SelectionPolygonVolume.cpp
+++ b/src/Visualization/Utility/SelectionPolygonVolume.cpp
@@ -29,6 +29,8 @@
 #include <json/json.h>
 #include <Core/Utility/Console.h>
 #include <Core/Geometry/PointCloud.h>
+#include <Core/Geometry/TriangleMesh.h>
+
 
 namespace open3d{
 
@@ -96,6 +98,21 @@ std::shared_ptr<PointCloud> SelectionPolygonVolume::CropPointCloudInPolygon(
 {
     return SelectDownSample(input, CropInPolygon(input.points_));
 }
+
+std::shared_ptr<TriangleMesh> SelectionPolygonVolume::CropTriangleMesh(
+        const TriangleMesh &input) const
+{
+    if (orthogonal_axis_ == "" || bounding_polygon_.empty())
+        return std::make_shared<TriangleMesh>();
+    return CropTriangleMeshInPolygon(input);
+}
+
+std::shared_ptr<TriangleMesh> SelectionPolygonVolume::CropTriangleMeshInPolygon(
+        const TriangleMesh &input) const
+{
+    return SelectDownSample(input, CropInPolygon(input.vertices_));
+}
+
 
 std::vector<size_t> SelectionPolygonVolume::CropInPolygon(
         const std::vector<Eigen::Vector3d> &input) const

--- a/src/Visualization/Utility/SelectionPolygonVolume.h
+++ b/src/Visualization/Utility/SelectionPolygonVolume.h
@@ -36,6 +36,7 @@ namespace open3d {
 
 class Geometry;
 class PointCloud;
+class TriangleMesh;
 
 class SelectionPolygonVolume : public IJsonConvertible
 {
@@ -46,10 +47,14 @@ public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
     std::shared_ptr<PointCloud> CropPointCloud(const PointCloud &input) const;
+    std::shared_ptr<TriangleMesh> CropTriangleMesh(const TriangleMesh &input) const;
+
 
 private:
     std::shared_ptr<PointCloud> CropPointCloudInPolygon(
             const PointCloud &input) const;
+    std::shared_ptr<TriangleMesh> CropTriangleMeshInPolygon(
+            const TriangleMesh &input) const;
     std::vector<size_t> CropInPolygon(
             const std::vector<Eigen::Vector3d> &input) const;
 


### PR DESCRIPTION
AFAIK there is no dedicated way to crop a TriangleMesh using a SelectionPolygonVolume (as created with the visualizer) via the python bindings. 

This PR would resolves this by adding the equivalent of the crop_point_cloud method for a TriangleMesh to SelectionPolygonVolume and the pybindings.

It seems to do exactly what I want, but I can't tell if this might cause a problem somewhere else. So feel free to see this as a feature request with reference implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/585)
<!-- Reviewable:end -->
