### PR TITLE
add `make check-style` and `make apply-style`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ ColumnLimit: 80
 UseTab: Never
 Language: Cpp
 Standard: Cpp11
+SortIncludes: false

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 .idea
 util/pip_package/dist/
 util/conda_package/dist/
+*.egg-info/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,3 +182,13 @@ add_subdirectory(src)
 
 # Examples
 add_subdirectory(examples)
+
+# `make check-style` returns non-zero exit code if styling is not compliant
+add_custom_target(check-style
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/util/scripts/check-style.sh
+)
+
+# `make apply-style` runs clang-format to format all source code
+add_custom_target(apply-style
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/util/scripts/apply-style.sh
+)

--- a/util/scripts/apply-style.sh
+++ b/util/scripts/apply-style.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+set -e
+set -u
+
+num_files=0
+num_files_formatted=0
+script_dir=`cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd`
+
+if ! [[ -x "$(command -v clang-format)" ]]; then
+    echo "Error: clang-format is not installed."
+    echo "On Ubuntu, run `apt-get install clang-format`"
+    echo "On Mac, run `brew install clang-format`"
+    exit 1
+fi
+
+pushd "${script_dir}/../.." > /dev/null
+for dir in src examples ; do
+    if ! [[ -d "${dir}" ]]; then
+        echo "Directory $(pwd)/${dir} not found$"
+        exit 1
+    fi
+
+    echo "Applying style in $(pwd)/${dir}"
+    for src_file in $(find "${dir}" -type f -and \( -name '*.cpp' -or -name '*.h' \)); do
+        file_diff=`diff -u <(cat ${src_file}) <(clang-format -style=file ${src_file}) || true`
+        if [[ ! -z ${file_diff} ]]; then
+            clang-format -style=file -i ${src_file}
+            echo "[formatted] ${src_file}"
+            num_files_formatted=$((num_files_formatted+1))
+        fi
+        num_files=$((num_files+1))
+    done
+done
+popd > /dev/null
+
+echo "${num_files_formatted} of ${num_files} files were reformatted"

--- a/util/scripts/check-style.sh
+++ b/util/scripts/check-style.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+set -e
+set -u
+
+num_files=0
+num_files_failed=0
+script_dir=`cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd`
+
+if ! [[ -x "$(command -v clang-format)" ]]; then
+    echo "Error: clang-format is not installed."
+    echo "On Ubuntu, run `apt-get install clang-format`"
+    echo "On Mac, run `brew install clang-format`"
+    exit 1
+fi
+
+pushd "${script_dir}/../.." > /dev/null
+for dir in src examples ; do
+    if ! [[ -d "${dir}" ]]; then
+        echo "Directory $(pwd)/${dir} not found"
+        exit 1
+    fi
+
+    echo "Checking style in $(pwd)/${dir}"
+    for src_file in $(find "${dir}" -type f -and \( -name '*.cpp' -or -name '*.h' \)); do
+        file_diff=`diff -u <(cat ${src_file}) <(clang-format -style=file ${src_file}) || true`
+        if [[ ! -z ${file_diff} ]]; then
+            echo "[failed] ${src_file}"
+            num_files_failed=$((num_files_failed+1))
+        fi
+        num_files=$((num_files+1))
+    done
+done
+popd > /dev/null
+
+if [[ ${num_files_failed} -eq 0 ]]; then
+    echo "${num_files_failed} of ${num_files} files failed the clang-format check"
+else
+    echo "${num_files_failed} of ${num_files} files failed the clang-format check"
+    exit 1
+fi


### PR DESCRIPTION
Second PR towards automatic format checking: https://github.com/IntelVCL/Open3D/pull/532

### Usage
For developers before submitting PR
```bash
make apply-style
```

For CI
```bash
make check-style
```

### Outputs
```
➜  ~/repo/Open3D/build (auto-format) make apply-style
...
Applying style in /Users/ylao/repo/Open3D/src
[formatted] src/Visualization/Shader/SimpleShader.h
[formatted] src/Visualization/Shader/PhongShader.cpp
[formatted] src/Visualization/Shader/GeometryRenderer.cpp
[formatted] src/Visualization/Shader/ImageMaskShader.h
...
297 of 304 files were reformatted
Built target apply-style
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/589)
<!-- Reviewable:end -->
