### PR TITLE
Use proper path concatenation in make_fragments.py

### DIFF
--- a/examples/Python/ReconstructionSystem/make_fragments.py
+++ b/examples/Python/ReconstructionSystem/make_fragments.py
@@ -123,7 +123,7 @@ def make_pointcloud_for_fragment(path_dataset, color_files, depth_files,
     pcd = PointCloud()
     pcd.points = mesh.vertices
     pcd.colors = mesh.vertex_colors
-    pcd_name = path_dataset + config["template_fragment_pointcloud"] % fragment_id
+    pcd_name = join(path_dataset, config["template_fragment_pointcloud"] % fragment_id)
     write_point_cloud(pcd_name, pcd, False, True)
 
 


### PR DESCRIPTION
Before this change, setting a path_dataset in the config which does not end on '/' leads to a wrong path here, making the fragment writing fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/610)
<!-- Reviewable:end -->
