### PR TITLE
Expose non-default constructor of VisualizerWithEdit in Python and add counter to automatic filename

### DIFF
--- a/src/Python/Visualization/open3d_visualizer.cpp
+++ b/src/Python/Visualization/open3d_visualizer.cpp
@@ -106,6 +106,7 @@ void pybind_visualizer(py::module &m)
     py::detail::bind_default_constructor<VisualizerWithEditing>(
             visualizer_edit);
     visualizer_edit
+        .def(py::init<double, bool, const std::string &>())
         .def("__repr__", [](const VisualizerWithEditing &vis) {
             return std::string("VisualizerWithEditing with name ") +
                     vis.GetWindowName();

--- a/src/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -377,7 +377,7 @@ void VisualizerWithEditing::KeyPressCallback(GLFWwindow *window,
                 const char *filename;
                 const char *pattern[1] = {"*.ply"};
                 std::string default_filename = default_directory_ +
-                        "cropped.ply";
+                        "cropped_" + std::to_string(crop_action_count_+1) + ".ply";
                 if (use_dialog_) {
                     filename = tinyfd_saveFileDialog("PointCloud file",
                             default_filename.c_str(), 1, pattern,
@@ -389,6 +389,7 @@ void VisualizerWithEditing::KeyPressCallback(GLFWwindow *window,
                     PrintInfo("No filename is given. Abort saving.\n");
                 } else {
                     SaveCroppingResult(filename);
+                    crop_action_count_++;
                 }
                 view_control.ToggleLocking();
                 InvalidateSelectionPolygon();
@@ -404,7 +405,7 @@ void VisualizerWithEditing::KeyPressCallback(GLFWwindow *window,
                 const char *filename;
                 const char *pattern[1] = {"*.ply"};
                 std::string default_filename = default_directory_ +
-                        "cropped.ply";
+                        "cropped_" + std::to_string(crop_action_count_+1) + ".ply";
                 if (use_dialog_) {
                     filename = tinyfd_saveFileDialog("Mesh file",
                             default_filename.c_str(), 1, pattern,
@@ -416,6 +417,7 @@ void VisualizerWithEditing::KeyPressCallback(GLFWwindow *window,
                     PrintInfo("No filename is given. Abort saving.\n");
                 } else {
                     SaveCroppingResult(filename);
+                    crop_action_count_++;                    
                 }
                 view_control.ToggleLocking();
                 InvalidateSelectionPolygon();

--- a/src/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -417,7 +417,7 @@ void VisualizerWithEditing::KeyPressCallback(GLFWwindow *window,
                     PrintInfo("No filename is given. Abort saving.\n");
                 } else {
                     SaveCroppingResult(filename);
-                    crop_action_count_++;                    
+                    crop_action_count_++;
                 }
                 view_control.ToggleLocking();
                 InvalidateSelectionPolygon();

--- a/src/Visualization/Visualizer/VisualizerWithEditing.h
+++ b/src/Visualization/Visualizer/VisualizerWithEditing.h
@@ -45,7 +45,8 @@ public:
 public:
     VisualizerWithEditing(double voxel_size = -1.0, bool use_dialog = true,
             const std::string &directory = "") : voxel_size_(voxel_size),
-            use_dialog_(use_dialog), default_directory_(directory) {}
+            use_dialog_(use_dialog),
+            default_directory_(directory) {}
     ~VisualizerWithEditing() override {}
     VisualizerWithEditing(const VisualizerWithEditing &) = delete;
     VisualizerWithEditing &operator=(const VisualizerWithEditing &) = delete;
@@ -89,6 +90,7 @@ protected:
     double voxel_size_ = -1.0;
     bool use_dialog_ = true;
     std::string default_directory_;
+    unsigned int crop_action_count_ = 0;
 };
 
 }    // namespace open3d


### PR DESCRIPTION
This PR aims to e xpose the VisualizerWithEdit constructor with arguments through its python bindings. Without one can not define the default filepath which very inconvenient. 

Additionally, this PR adds a counter to the "cropped.ply" file, since most likely one will apply more than one cropping (and requires all to obtain the same final results when loading and applying the crop selections). The counter is only increased if a file is actually saved (although by that point, the point cloud already changed, and the user might start over anyway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/630)
<!-- Reviewable:end -->
