### PR TITLE
Fix Conda and Pip packaging issues

### DIFF
--- a/src/Python/Package/conda_meta/meta.yaml
+++ b/src/Python/Package/conda_meta/meta.yaml
@@ -18,7 +18,10 @@ requirements:
         - setuptools
     run:
         - python
-        - numpy
+        - ipywidgets >=7.4.2
+        - widgetsnbextension >=3.4.2
+        - notebook >=5.7.0
+        - numpy >=1.11.0
 
 test:
     script:

--- a/src/Python/Package/conda_meta/meta.yaml
+++ b/src/Python/Package/conda_meta/meta.yaml
@@ -18,10 +18,10 @@ requirements:
         - setuptools
     run:
         - python
-        - ipywidgets >=7.4.2
-        - widgetsnbextension >=3.4.2
-        - notebook >=5.7.0
-        - numpy >=1.11.0
+        - ipywidgets
+        - widgetsnbextension
+        - notebook
+        - numpy
 
 test:
     script:

--- a/src/Python/Package/open3d/__init__.py
+++ b/src/Python/Package/open3d/__init__.py
@@ -31,7 +31,7 @@ globals().update(importlib.import_module('open3d.open3d').__dict__)
 __version__ = '@PROJECT_VERSION@'
 
 if "@JUPYTER_ENABLED@" == "ON":
-    from .j_visualizer import *
+    from open3d.j_visualizer import *
 
     def _jupyter_nbextension_paths():
         return [{

--- a/src/Python/Package/requirements.txt
+++ b/src/Python/Package/requirements.txt
@@ -1,4 +1,4 @@
 ipywidgets>=7.4.2
 widgetsnbextension>=3.4.2
 notebook>=5.7.0
-numpy
+numpy>=1.11.0

--- a/src/Python/Package/requirements.txt
+++ b/src/Python/Package/requirements.txt
@@ -1,4 +1,4 @@
-ipywidgets>=7.4.2
-widgetsnbextension>=3.4.2
-notebook>=5.7.0
-numpy>=1.11.0
+ipywidgets
+widgetsnbextension
+notebook
+numpy

--- a/src/Python/Package/setup.cfg
+++ b/src/Python/Package/setup.cfg
@@ -5,6 +5,3 @@
 [metadata]
 
 license_file = LICENSE.txt
-
-[bdist_wheel]
-universal=1

--- a/src/Python/Package/setup.py
+++ b/src/Python/Package/setup.py
@@ -26,6 +26,14 @@
 
 from setuptools import setup, find_packages
 import glob
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+    class bdist_wheel(_bdist_wheel):
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
+except ImportError:
+    bdist_wheel = None
 
 # Read requirements.txt
 with open('requirements.txt', 'r') as f:
@@ -78,6 +86,7 @@ setup(
     description=[
         "Open3D is an open-source library that supports rapid development of software that deals with 3D data."
     ],
+    cmdclass={'bdist_wheel': bdist_wheel},
     install_requires=install_requires,
     include_package_data=True,
     data_files=data_files,

--- a/src/Python/check_and_install_conda_deps.cmake
+++ b/src/Python/check_and_install_conda_deps.cmake
@@ -1,11 +1,3 @@
-# Check if conda in path, if not, throw exception
-find_program(CONDA "conda")
-if (NOT CONDA)
-    message(FATAL_ERROR "conda not found, please install, see https://conda.io/docs/user-guide/install/index.html")
-else ()
-    message(STATUS "conda is found at ${CONDA}")
-endif()
-
 # Assert that we're inside a conda environemnt
 message(STATUS "Asserting this is Conda python: ${PYTHON_EXECUTABLE} ...")
 execute_process(


### PR DESCRIPTION
Several fixes related to Conda and Pip packaging:
- Build platform-specific targets (instead of `any` `none`) for wheel
- Fixed python 2.7 import `JVisulizer`
- Fixed conda dependency conflicts (resulting in forced downgrade)
- Disabled conda executable check (`conda` command could be a bash function instead of an executable, CMake may complain)