### PR TITLE
Add option to disable jupyter build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ option(BUILD_PYBIND11            "Build pybind11 from source"               ON)
 option(BUILD_PYTHON_MODULE       "Build the python module"                  ON)
 option(BUILD_LIBREALSENSE        "Build support for Intel RealSense camera" OFF)
 option(BUILD_TINYFILEDIALOGS     "Build tinyfiledialogs from source"        ON)
+option(ENABLE_JUPYTER            "Enable Jupyter support for Open3D"        ON)
 
 # default built type
 if (NOT CMAKE_BUILD_TYPE)

--- a/src/Python/CMakeLists.txt
+++ b/src/Python/CMakeLists.txt
@@ -14,14 +14,15 @@ message(STATUS "Using Python executable: ${PYTHON_EXECUTABLE}")
 # Detect whether `npm` is installed. Jupyter support will only be enabled if
 # `npm` is found.
 find_program(NPM "npm")
-option(JUPYTER_ENABLED "Enable Jupyter support for Open3D" ON)
-if (NOT NPM)
-    message(WARNING "Cannot find npm. Jupyter support will be disabled.")
-    set(JUPYTER_ENABLED OFF)
-else()
-    message(STATUS "npm found at: ${NPM}. Jupyter support will be disabled.")
+if (ENABLE_JUPYTER)
+    if (NOT NPM)
+        message(WARNING "Cannot find npm. Jupyter support will be disabled.")
+        set(ENABLE_JUPYTER OFF)
+    else()
+        message(STATUS "npm found at: ${NPM}. Jupyter support will be enabled.")
+    endif()
 endif()
-message(STATUS "JUPYTER_ENABLED is set to ${JUPYTER_ENABLED}")
+message(STATUS "ENABLE_JUPYTER is set to ${ENABLE_JUPYTER}")
 
 # We need to get python version to configure some meta files
 execute_process(
@@ -70,7 +71,7 @@ add_custom_target(python-package
             -DPYTHON_PACKAGE_DST_DIR=${PYTHON_PACKAGE_DST_DIR}
             -DPYTHON_VERSION=${PYTHON_VERSION}
             -DPYTHON_COMPILED_MODULE_PATH=$<TARGET_FILE:${PACKAGE_NAME}>
-            -DJUPYTER_ENABLED=${JUPYTER_ENABLED}
+            -DENABLE_JUPYTER=${ENABLE_JUPYTER}
             -DPROJECT_EMAIL=${PROJECT_EMAIL}
             -DPROJECT_HOME=${PROJECT_HOME}
             -DPROJECT_DOCS=${PROJECT_DOCS}

--- a/src/Python/Package/open3d/__init__.py
+++ b/src/Python/Package/open3d/__init__.py
@@ -30,7 +30,7 @@ globals().update(importlib.import_module('open3d.open3d').__dict__)
 
 __version__ = '@PROJECT_VERSION@'
 
-if "@JUPYTER_ENABLED@" == "ON":
+if "@ENABLE_JUPYTER@" == "ON":
     from open3d.j_visualizer import *
 
     def _jupyter_nbextension_paths():

--- a/src/Python/make_python_package.cmake
+++ b/src/Python/make_python_package.cmake
@@ -36,7 +36,7 @@ configure_file("${PYTHON_PACKAGE_SRC_DIR}/js/package.json"
 # Build Jupyter plugin with webpack. This step distills and merges all js
 # dependencies and include all static assets. The generated output is in
 # ${PYTHON_PACKAGE_DST_DIR}/open3d/static.
-if (JUPYTER_ENABLED)
+if (ENABLE_JUPYTER)
     file(REMOVE_RECURSE ${PYTHON_PACKAGE_DST_DIR}/open3d/static)
     message(STATUS "Jupyter support is enabled. Building Jupyter plugin ...")
     if (WIN32)


### PR DESCRIPTION
Before: all based on whether `npm` is detected
Now: only when `ENABLE_JUPYTER=ON`, cmake will try to detect `npm`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/655)
<!-- Reviewable:end -->
