### PR TITLE
Vector3dvector and other vector Eigen bindings speed up

### DIFF
--- a/src/UnitTest/Python/readme.md
+++ b/src/UnitTest/Python/readme.md
@@ -1,0 +1,20 @@
+# Python Unit Test
+
+Install:
+
+```bash
+pip install pytest
+```
+
+Run:
+
+```bash
+# Picks up all files named "test_*.py", and runs all functions named "test_*"
+pytest
+
+# Or point to a test directory, e.g.
+pytest /path/to/root/test/directory
+
+# Use -s to show stdout
+pytest -s
+```

--- a/src/UnitTest/Python/test_open3d_eigen.py
+++ b/src/UnitTest/Python/test_open3d_eigen.py
@@ -1,0 +1,200 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d
+import numpy as np
+import time
+import pytest
+
+@pytest.mark.parametrize("input_array, expect_exception", [
+    # Empty case
+    (np.ones((0, 3), dtype=np.float64), False),
+    # Wrong shape
+    (np.ones((2, 4), dtype=np.float64), True),
+    # Non-numpy array
+    ([[1, 2, 3], [4, 5, 6]], False),
+    ([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], False),
+    # Datatypes
+    (np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64), False),
+    (np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32), False),
+    (np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32), False),
+    # Slice non-contiguous memory
+    (np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], dtype=np.float64)[:, 0:6:2], False),
+    # Transpose view
+    (np.array([[1, 4], [2, 5], [3, 6]], dtype=np.float64).T, False),
+    # Fortran layout
+    (np.asfortranarray(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64)), False),
+])
+def test_Vector3dVector(input_array, expect_exception):
+    def run_test(input_array):
+        open3d_array = open3d.Vector3dVector(input_array)
+        output_array = np.asarray(open3d_array)
+        np.testing.assert_allclose(input_array, output_array)
+
+    if expect_exception:
+        with pytest.raises(Exception):
+            run_test(input_array)
+    else:
+        run_test(input_array)
+
+@pytest.mark.parametrize("input_array, expect_exception", [
+    # Empty case
+    (np.ones((0, 3), dtype=np.int32), False),
+    # Wrong shape
+    (np.ones((2, 4), dtype=np.int32), True),
+    # Non-numpy array
+    ([[1, 2, 3], [4, 5, 6]], False),
+    ([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], False),
+    # Datatypes
+    (np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64), False),
+    (np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32), False),
+    (np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32), False),
+    # Slice non-contiguous memory
+    (np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], dtype=np.int32)[:, 0:6:2], False),
+    # Transpose view
+    (np.array([[1, 4], [2, 5], [3, 6]], dtype=np.int32).T, False),
+    # Fortran layout
+    (np.asfortranarray(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)), False),
+])
+def test_Vector3iVector(input_array, expect_exception):
+    def run_test(input_array):
+        open3d_array = open3d.Vector3iVector(input_array)
+        output_array = np.asarray(open3d_array)
+        np.testing.assert_allclose(input_array, output_array)
+
+    if expect_exception:
+        with pytest.raises(Exception):
+            run_test(input_array)
+    else:
+        run_test(input_array)
+
+
+@pytest.mark.parametrize("input_array, expect_exception", [
+    # Empty case
+    (np.ones((0, 2), dtype=np.int32), False),
+    # Wrong shape
+    (np.ones((10, 3), dtype=np.int32), True),
+    # Non-numpy array
+    ([[1, 2], [4, 5]], False),
+    ([[1.0, 2.0], [4.0, 5.0]], False),
+    # Datatypes
+    (np.array([[1, 2], [4, 5]], dtype=np.float64), False),
+    (np.array([[1, 2], [4, 5]], dtype=np.int32), False),
+    (np.array([[1, 2], [4, 5]], dtype=np.int32), False),
+    # Slice non-contiguous memory
+    (np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], dtype=np.int32)[:, 0:6:3], False),
+    # Transpose view
+    (np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32).T, False),
+    # Fortran layout
+    (np.asfortranarray(np.array([[1, 2], [4, 5]], dtype=np.int32)), False),
+])
+def test_Vector2iVector(input_array, expect_exception):
+    def run_test(input_array):
+        open3d_array = open3d.Vector2iVector(input_array)
+        output_array = np.asarray(open3d_array)
+        np.testing.assert_allclose(input_array, output_array)
+
+    if expect_exception:
+        with pytest.raises(Exception):
+            run_test(input_array)
+    else:
+        run_test(input_array)
+
+
+@pytest.mark.parametrize("input_array, expect_exception", [
+    # Empty case
+    (np.ones((0, 4, 4), dtype=np.float64), False),
+    # Wrong shape
+    (np.ones((10, 3), dtype=np.float64), True),
+    (np.ones((10, 3, 3), dtype=np.float64), True),
+    # Non-numpy array
+    ([[[ 0,  1,  2,  3],
+        [ 4,  5,  6,  7],
+        [ 8,  9, 10, 11],
+        [12, 13, 14, 15]]], False),
+    # Datatypes
+    (np.random.randint(10, size=(10, 4, 4)).astype(np.float64), False),
+    (np.random.randint(10, size=(10, 4, 4)).astype(np.int32), False),
+    # Slice non-contiguous memory
+    (np.random.random((10, 8, 8)).astype(np.float64)[:, 0:8:2, 0:8:2], False),
+    # Fortran layout
+    (np.asfortranarray(np.array(np.random.random((10, 4, 4)), dtype=np.float64)), False),
+])
+def test_Matrix4dVector(input_array, expect_exception):
+    def run_test(input_array):
+        open3d_array = open3d.Matrix4dVector(input_array)
+        output_array = np.asarray(open3d_array)
+        np.testing.assert_allclose(input_array, output_array)
+
+    if expect_exception:
+        with pytest.raises(Exception):
+            run_test(input_array)
+    else:
+        run_test(input_array)
+
+# Run with pytest -s to show output
+def test_benchmark():
+    vector_size = int(2e6)
+
+    x = np.random.randint(10, size=(vector_size, 3)).astype(np.float64)
+    print("\nopen3d.Vector3dVector:", x.shape)
+    start_time = time.time()
+    y = open3d.Vector3dVector(x)
+    print("open3d -> numpy: %.6fs" % (time.time() - start_time))
+    start_time = time.time()
+    z = np.asarray(y)
+    print("numpy -> open3d: %.6fs" % (time.time() - start_time))
+    np.testing.assert_allclose(x, z)
+
+    print("\nopen3d.Vector3iVector:", x.shape)
+    x = np.random.randint(10, size=(vector_size, 3)).astype(np.int32)
+    start_time = time.time()
+    y = open3d.Vector3iVector(x)
+    print("open3d -> numpy: %.6fs" % (time.time() - start_time))
+    start_time = time.time()
+    z = np.asarray(y)
+    print("numpy -> open3d: %.6fs" % (time.time() - start_time))
+    np.testing.assert_allclose(x, z)
+
+    print("\nopen3d.Vector2iVector:", x.shape)
+    x = np.random.randint(10, size=(vector_size, 2)).astype(np.int32)
+    start_time = time.time()
+    y = open3d.Vector2iVector(x)
+    print("open3d -> numpy: %.6fs" % (time.time() - start_time))
+    start_time = time.time()
+    z = np.asarray(y)
+    print("numpy -> open3d: %.6fs" % (time.time() - start_time))
+    np.testing.assert_allclose(x, z)
+
+    print("\nopen3d.Matrix4dVector:", x.shape)
+    x = np.random.randint(10, size=(vector_size, 4, 4)).astype(np.float64)
+    start_time = time.time()
+    y = open3d.Matrix4dVector(x)
+    print("open3d -> numpy: %.6fs" % (time.time() - start_time))
+    start_time = time.time()
+    z = np.asarray(y)
+    print("numpy -> open3d: %.6fs" % (time.time() - start_time))
+    np.testing.assert_allclose(x, z)


### PR DESCRIPTION
Improves speed of `open3d.Vector3dVector`, `Vector3iVector`, `Vector2iVector`, `Matrix4dVector` by 10-200x, based on issue https://github.com/IntelVCL/Open3D/issues/403 and https://github.com/pybind/pybind11/issues/1481. 

Special thanks to Wenzel's feedback. According to Wenzel, the slowness is due to "casting millions of small vectors, which requires a proportional amount of Python API calls".

### Comparison
Before
```
open3d.Vector3dVector: (2000000, 3)
open3d -> numpy: 1.005225s
numpy -> open3d: 0.000018s

open3d.Vector3iVector: (2000000, 3)
open3d -> numpy: 0.983502s
numpy -> open3d: 0.001925s

open3d.Vector2iVector: (2000000, 3)
open3d -> numpy: 0.944884s
numpy -> open3d: 0.000886s

open3d.Matrix4dVector: (2000000, 2)
open3d -> numpy: 1.236172s
numpy -> open3d: 0.000017s
```
After
```
open3d.Vector3dVector: (2000000, 3)
open3d -> numpy: 0.024798s
numpy -> open3d: 0.000017s

open3d.Vector3iVector: (2000000, 3)
open3d -> numpy: 0.010451s
numpy -> open3d: 0.001906s

open3d.Vector2iVector: (2000000, 3)
open3d -> numpy: 0.005553s
numpy -> open3d: 0.000865s

open3d.Matrix4dVector: (2000000, 2)
open3d -> numpy: 0.091531s
numpy -> open3d: 0.000020s
```

### Discussions
This solution is not ideal yet:
1) We pay the copy penalty. The way to avoid this is to replace the underlying storage of say `vector<Eigen::Vector3d>` to one blob of buffer. However, this requires significant rework of the code base. 
2) We pay the penalty handling non-contiguous numpy arrays by assesing array index individually. If we can assert that the incoming array is contiguous, we could use more direct memory mapping.

### Future works
Some of the templated functions can be further merged. Please let me know if you have suggestions. 