### PR TITLE
Fix windows compilation warning with py::ssize_t

### DIFF
--- a/src/Python/open3d_eigen.cpp
+++ b/src/Python/open3d_eigen.cpp
@@ -59,7 +59,7 @@ std::vector<EigenVector> py_array_to_vectors_double(
     }
     std::vector<EigenVector> eigen_vectors(array.shape(0));
     auto array_unchecked = array.mutable_unchecked<2>();
-    for (py::ssize_t i = 0; i < array_unchecked.shape(0); ++i) {
+    for (auto i = 0; i < array_unchecked.shape(0); ++i) {
         // The EigenVector here must be a double-typed eigen vector, since only
         // open3d::Vector3dVector binds to py_array_to_vectors_double.
         // Therefore, we can use the memory map directly.
@@ -77,7 +77,7 @@ std::vector<EigenVector> py_array_to_vectors_int(
     }
     std::vector<EigenVector> eigen_vectors(array.shape(0));
     auto array_unchecked = array.mutable_unchecked<2>();
-    for (py::ssize_t i = 0; i < array_unchecked.shape(0); ++i) {
+    for (auto i = 0; i < array_unchecked.shape(0); ++i) {
         eigen_vectors[i] = Eigen::Map<EigenVector>(&array_unchecked(i, 0));
     }
     return eigen_vectors;

--- a/src/Python/open3d_eigen.cpp
+++ b/src/Python/open3d_eigen.cpp
@@ -59,7 +59,7 @@ std::vector<EigenVector> py_array_to_vectors_double(
     }
     std::vector<EigenVector> eigen_vectors(array.shape(0));
     auto array_unchecked = array.mutable_unchecked<2>();
-    for (size_t i = 0; i < array_unchecked.shape(0); ++i) {
+    for (py::ssize_t i = 0; i < array_unchecked.shape(0); ++i) {
         // The EigenVector here must be a double-typed eigen vector, since only
         // open3d::Vector3dVector binds to py_array_to_vectors_double.
         // Therefore, we can use the memory map directly.
@@ -77,7 +77,7 @@ std::vector<EigenVector> py_array_to_vectors_int(
     }
     std::vector<EigenVector> eigen_vectors(array.shape(0));
     auto array_unchecked = array.mutable_unchecked<2>();
-    for (size_t i = 0; i < array_unchecked.shape(0); ++i) {
+    for (py::ssize_t i = 0; i < array_unchecked.shape(0); ++i) {
         eigen_vectors[i] = Eigen::Map<EigenVector>(&array_unchecked(i, 0));
     }
     return eigen_vectors;


### PR DESCRIPTION
Fixed warning: 
```
 c:\users\linux\repo\open3d\src\python\open3d_eigen.cpp(235): note: see reference to function template instantiation 'std::vecto
         r<Eigen::Vector3d,std::allocator<_Ty>> pybind11::py_array_to_vectors_double<Eigen::Vector3d>(pybind11::array_t<double,17>)' bei
         ng compiled
                 with
                 [
                     _Ty=Eigen::Vector3d
                 ]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/662)
<!-- Reviewable:end -->
