### PR TITLE
Adding warning output for "degenerated" TriangleMeshes

### DIFF
--- a/src/IO/ClassIO/TriangleMeshIO.cpp
+++ b/src/IO/ClassIO/TriangleMeshIO.cpp
@@ -73,6 +73,10 @@ bool ReadTriangleMesh(const std::string &filename, TriangleMesh &mesh)
     bool success = map_itr->second(filename, mesh);
     PrintDebug("Read TriangleMesh: %d triangles and %d vertices.\n",
             (int)mesh.triangles_.size(), (int)mesh.vertices_.size());
+    if (mesh.HasVertices() && !mesh.HasTriangles()) {
+        PrintWarning("TriangleMesh appears to be a PointCloud (only contains "
+            "vertices, but no triangles).\n");
+    }
     return success;
 }
 

--- a/src/Visualization/Utility/SelectionPolygon.cpp
+++ b/src/Visualization/Utility/SelectionPolygon.cpp
@@ -134,6 +134,12 @@ std::shared_ptr<TriangleMesh> SelectionPolygon::CropTriangleMesh(
     if (IsEmpty()) {
         return std::make_shared<TriangleMesh>();
     }
+    if (input.HasVertices() && !input.HasTriangles()) {
+        PrintWarning(
+            "TriangleMesh contains vertices, but no triangles; "
+            "cropping will always yield an empty TriangleMesh.\n");
+        return std::make_shared<TriangleMesh>();
+    }
     switch (polygon_type_) {
     case SectionPolygonType::Rectangle:
         return CropTriangleMeshInRectangle(input, view);

--- a/src/Visualization/Utility/SelectionPolygonVolume.cpp
+++ b/src/Visualization/Utility/SelectionPolygonVolume.cpp
@@ -58,7 +58,7 @@ bool SelectionPolygonVolume::ConvertFromJsonValue(const Json::Value &value)
 {
     if (value.isObject() == false) {
         PrintWarning("SelectionPolygonVolume read JSON failed: unsupported json format.\n");
-        return false;        
+        return false;
     }
     if (value.get("class_name", "").asString() != "SelectionPolygonVolume" ||
             value.get("version_major", 1).asInt() != 1 ||
@@ -104,6 +104,12 @@ std::shared_ptr<TriangleMesh> SelectionPolygonVolume::CropTriangleMesh(
 {
     if (orthogonal_axis_ == "" || bounding_polygon_.empty())
         return std::make_shared<TriangleMesh>();
+    if (input.HasVertices() && !input.HasTriangles()) {
+        PrintWarning(
+            "TriangleMesh contains vertices, but no triangles; "
+            "cropping will always yield an empty TriangleMesh.\n");
+        return std::make_shared<TriangleMesh>();
+    }
     return CropTriangleMeshInPolygon(input);
 }
 


### PR DESCRIPTION
This PR adds the following behavior:

- Emit a warning during reading IO (ReadTriangleMesh), if input PLY is a pointcloud (contains zero/no faces).
- Emit a warning when calling CropTriangleMesh from a SelectionPolygonVolume if TriangleMesh is only a PointCloud
- Emit a warning when calling CropTriangleMesh from a SelectionPolygon  if TriangleMesh is only a PointCloud


Possible problems/short comings of this PR (imo):

- Depending on whether one wants to introduce some terminology like "degenerated TM", then this piece of code `mesh.HasVertices() && !mesh.HasTriangles()` could also be made a member function of TriangleMesh like `isEmpty`.  This raises the questions, what about TriangleMeshes with vertices, triangles, but also N unconnected vertices (e.g., hasUnconnectedVertices() ). How should they be treated?
- The section in SelectionPolygon.cpp is possibly "useless", since it seems visualizing an empty TriangleMesh doesn't work in the first place, so the whole part probably can't be accessed (considering the remaining logical flow, but I might be missing something here)
`
 [SimpleShaderForTriangleMesh] Binding failed with empty triangle mesh.
  [SimpleShaderForTriangleMesh] Binding failed when preparing data.
  [SimpleShaderForTriangleMesh] Something is wrong in compiling or binding.
  [SimpleShaderForTriangleMesh] Binding failed with empty triangle mesh.
  [SimpleShaderForTriangleMesh] Binding failed when preparing data.
  [SimpleShaderForTriangleMesh] Something is wrong in compiling or binding.
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/678)
<!-- Reviewable:end -->
