### PR TITLE
Constructor initialization

### DIFF
--- a/src/Core/Camera/PinholeCameraIntrinsic.cpp
+++ b/src/Core/Camera/PinholeCameraIntrinsic.cpp
@@ -32,7 +32,8 @@
 
 namespace open3d{
 
-PinholeCameraIntrinsic::PinholeCameraIntrinsic()
+PinholeCameraIntrinsic::PinholeCameraIntrinsic() : width_(-1), height_(-1),
+    intrinsic_matrix_(Eigen::Matrix3d::Zero())
 {
 }
 


### PR DESCRIPTION
fixed bug due to PinholeCameraIntrinsic constructor not initializing member data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/684)
<!-- Reviewable:end -->
