### PR TITLE
PinholeCameraIntrinsic

### DIFF
--- a/src/Core/Camera/PinholeCameraIntrinsic.cpp
+++ b/src/Core/Camera/PinholeCameraIntrinsic.cpp
@@ -32,7 +32,8 @@
 
 namespace open3d{
 
-PinholeCameraIntrinsic::PinholeCameraIntrinsic()
+PinholeCameraIntrinsic::PinholeCameraIntrinsic() : width_(-1), height_(-1),
+    intrinsic_matrix_(Eigen::Matrix3d::Zero())
 {
 }
 

--- a/src/UnitTest/Core/Camera/PinholeCameraIntrinsic.cpp
+++ b/src/UnitTest/Core/Camera/PinholeCameraIntrinsic.cpp
@@ -26,20 +26,104 @@
 
 #include "UnitTest.h"
 
+#include "Core/Camera/PinholeCameraIntrinsic.h"
+#include <json/json.h>
+
+using namespace Eigen;
+using namespace open3d;
+using namespace std;
+using namespace unit_test;
+
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_Constructor)
+TEST(PinholeCameraIntrinsic, Constructor_Default)
 {
-    unit_test::NotImplemented();
+    PinholeCameraIntrinsic intrinsic;
+
+    EXPECT_EQ(-1, intrinsic.width_);
+    EXPECT_EQ(-1, intrinsic.height_);
+
+    Matrix3d reference = Matrix3d::Zero();
+    ExpectEQ(reference, intrinsic.intrinsic_matrix_);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_Destructor)
+TEST(PinholeCameraIntrinsic, Constructor_PrimeSenseDefault)
 {
-    unit_test::NotImplemented();
+    PinholeCameraIntrinsic intrinsic(
+        PinholeCameraIntrinsicParameters::PrimeSenseDefault);
+
+    EXPECT_EQ(640, intrinsic.width_);
+    EXPECT_EQ(480, intrinsic.height_);
+
+    Matrix3d reference;
+    reference << 525.0, 0.0, 319.5, 0.0, 525.0, 239.5, 0.0, 0.0, 1.0;
+
+    ExpectEQ(reference, intrinsic.intrinsic_matrix_);
+}
+
+// ----------------------------------------------------------------------------
+//
+// ----------------------------------------------------------------------------
+TEST(PinholeCameraIntrinsic, Constructor_Kinect2DepthCameraDefault)
+{
+    PinholeCameraIntrinsic intrinsic(
+        PinholeCameraIntrinsicParameters::Kinect2DepthCameraDefault);
+
+    EXPECT_EQ(512, intrinsic.width_);
+    EXPECT_EQ(424, intrinsic.height_);
+
+    Matrix3d reference;
+    reference << 254.878, 0.0, 365.456, 0.0, 205.395, 365.456, 0.0, 0.0, 1.0;
+
+    ExpectEQ(reference, intrinsic.intrinsic_matrix_);
+}
+
+// ----------------------------------------------------------------------------
+//
+// ----------------------------------------------------------------------------
+TEST(PinholeCameraIntrinsic, Constructor_Kinect2ColorCameraDefault)
+{
+    PinholeCameraIntrinsic intrinsic(
+        PinholeCameraIntrinsicParameters::Kinect2ColorCameraDefault);
+
+    EXPECT_EQ(1920, intrinsic.width_);
+    EXPECT_EQ(1080, intrinsic.height_);
+
+    Matrix3d reference;
+    reference << 1059.9718,       0.0, 975.7193,
+                       0.0, 1059.9718, 545.9533,
+                       0.0,       0.0,      1.0;
+
+    ExpectEQ(reference, intrinsic.intrinsic_matrix_);
+}
+
+// ----------------------------------------------------------------------------
+//
+// ----------------------------------------------------------------------------
+TEST(PinholeCameraIntrinsic, Constructor_Init)
+{
+    int width = 640;
+    int height = 480;
+
+    double fx = 0.5;
+    double fy = 0.65;
+
+    double cx = 0.75;
+    double cy = 0.35;
+
+    PinholeCameraIntrinsic intrinsic(width, height, fx, fy, cx, cy);
+
+    EXPECT_EQ(width, intrinsic.width_);
+    EXPECT_EQ(height, intrinsic.height_);
+
+    Matrix3d reference;
+    reference << fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0;
+
+    ExpectEQ(reference, intrinsic.intrinsic_matrix_);
 }
 
 // ----------------------------------------------------------------------------
@@ -53,55 +137,169 @@ TEST(PinholeCameraIntrinsic, DISABLED_MemberData)
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_SetIntrinsics)
+TEST(PinholeCameraIntrinsic, SetIntrinsics)
 {
-    unit_test::NotImplemented();
+    PinholeCameraIntrinsic intrinsic;
+
+    EXPECT_EQ(-1, intrinsic.width_);
+    EXPECT_EQ(-1, intrinsic.height_);
+
+    intrinsic.intrinsic_matrix_ = Matrix3d::Zero();
+
+    int width = 640;
+    int height = 480;
+
+    double fx = 0.5;
+    double fy = 0.65;
+
+    double cx = 0.75;
+    double cy = 0.35;
+
+    intrinsic.SetIntrinsics(width, height, fx, fy, cx, cy);
+
+    EXPECT_EQ(width, intrinsic.width_);
+    EXPECT_EQ(height, intrinsic.height_);
+
+    Matrix3d reference;
+    reference << fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0;
+
+    ExpectEQ(reference, intrinsic.intrinsic_matrix_);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_GetFocalLength)
+TEST(PinholeCameraIntrinsic, GetFocalLength)
 {
-    unit_test::NotImplemented();
+    PinholeCameraIntrinsic intrinsic;
+
+    int width = 640;
+    int height = 480;
+
+    double fx = 0.5;
+    double fy = 0.65;
+
+    double cx = 0.75;
+    double cy = 0.35;
+
+    intrinsic.SetIntrinsics(width, height, fx, fy, cx, cy);
+
+    EXPECT_EQ(width, intrinsic.width_);
+    EXPECT_EQ(height, intrinsic.height_);
+
+    pair<double, double> output = intrinsic.GetFocalLength();
+
+    EXPECT_NEAR(fx, output.first, THRESHOLD_1E_6);
+    EXPECT_NEAR(fy, output.second, THRESHOLD_1E_6);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_GetPrincipalPoint)
+TEST(PinholeCameraIntrinsic, GetPrincipalPoint)
 {
-    unit_test::NotImplemented();
+    PinholeCameraIntrinsic intrinsic;
+
+    int width = 640;
+    int height = 480;
+
+    double fx = 0.5;
+    double fy = 0.65;
+
+    double cx = 0.75;
+    double cy = 0.35;
+
+    intrinsic.SetIntrinsics(width, height, fx, fy, cx, cy);
+
+    EXPECT_EQ(width, intrinsic.width_);
+    EXPECT_EQ(height, intrinsic.height_);
+
+    pair<double, double> output = intrinsic.GetPrincipalPoint();
+
+    EXPECT_NEAR(cx, output.first, THRESHOLD_1E_6);
+    EXPECT_NEAR(cy, output.second, THRESHOLD_1E_6);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_GetSkew)
+TEST(PinholeCameraIntrinsic, GetSkew)
 {
-    unit_test::NotImplemented();
+    PinholeCameraIntrinsic intrinsic;
+
+    int width = 640;
+    int height = 480;
+
+    double fx = 0.5;
+    double fy = 0.65;
+
+    double cx = 0.75;
+    double cy = 0.35;
+
+    intrinsic.SetIntrinsics(width, height, fx, fy, cx, cy);
+
+    EXPECT_EQ(width, intrinsic.width_);
+    EXPECT_EQ(height, intrinsic.height_);
+
+    double output = intrinsic.GetSkew();
+
+    EXPECT_NEAR(0.0, output, THRESHOLD_1E_6);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_IsValid)
+TEST(PinholeCameraIntrinsic, IsValid)
 {
-    unit_test::NotImplemented();
+    PinholeCameraIntrinsic intrinsic;
+
+    EXPECT_FALSE(intrinsic.IsValid());
+
+    int width = 640;
+    int height = 480;
+
+    double fx = 0.5;
+    double fy = 0.65;
+
+    double cx = 0.75;
+    double cy = 0.35;
+
+    intrinsic.SetIntrinsics(width, height, fx, fy, cx, cy);
+
+    EXPECT_TRUE(intrinsic.IsValid());
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_ConvertToJsonValue)
+TEST(PinholeCameraIntrinsic, ConvertToFromJsonValue)
 {
-    unit_test::NotImplemented();
-}
+    PinholeCameraIntrinsic src;
+    PinholeCameraIntrinsic dst;
 
-// ----------------------------------------------------------------------------
-//
-// ----------------------------------------------------------------------------
-TEST(PinholeCameraIntrinsic, DISABLED_ConvertFromJsonValue)
-{
-    unit_test::NotImplemented();
+    int width = 640;
+    int height = 480;
+
+    double fx = 0.5;
+    double fy = 0.65;
+
+    double cx = 0.75;
+    double cy = 0.35;
+
+    src.SetIntrinsics(width, height, fx, fy, cx, cy);
+
+    Json::Value value;
+    bool output = src.ConvertToJsonValue(value);
+    EXPECT_TRUE(output);
+
+    output = dst.ConvertFromJsonValue(value);
+    EXPECT_TRUE(output);
+
+    EXPECT_EQ(width, dst.width_);
+    EXPECT_EQ(height, dst.height_);
+
+    Matrix3d reference;
+    reference << fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0;
+
+    ExpectEQ(reference, dst.intrinsic_matrix_);
 }


### PR DESCRIPTION
implemented the PinholeCameraIntrinsic test case.
fixed bug in PinholeCameraIntrinsic: uninitialized member data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/689)
<!-- Reviewable:end -->
