### PR TITLE
Factorize internal functions for ColormapOptimization module

### DIFF
--- a/src/Core/ColorMap/ColorMapOptimization.cpp
+++ b/src/Core/ColorMap/ColorMapOptimization.cpp
@@ -26,66 +26,18 @@
 
 #include "ColorMapOptimization.h"
 
-#include <Core/ColorMap/ColorMapOptimizationJacobian.h>
 #include <Core/Camera/PinholeCameraTrajectory.h>
+#include <Core/ColorMap/ColorMapOptimizationJacobian.h>
+#include <Core/ColorMap/ImageWarpingField.h>
 #include <Core/Geometry/Image.h>
 #include <Core/Geometry/RGBDImage.h>
 #include <Core/Geometry/TriangleMesh.h>
 #include <Core/Utility/Console.h>
 #include <Core/Utility/Eigen.h>
-#include <IO/ClassIO/TriangleMeshIO.h>
 
 namespace open3d {
 
 namespace {
-
-class ImageWarpingField {
-
-public:
-    ImageWarpingField (int width, int height, int number_of_vertical_anchors) {
-        InitializeWarpingFields(width, height, number_of_vertical_anchors);
-    }
-
-    void InitializeWarpingFields(int width, int height,
-            int number_of_vertical_anchors) {
-        anchor_h_ = number_of_vertical_anchors;
-        anchor_step_ = double(height) / (anchor_h_ - 1);
-        anchor_w_ = int(std::ceil(double(width) / anchor_step_) + 1);
-        flow_ = Eigen::VectorXd(anchor_w_ * anchor_h_ * 2);
-        for (int i = 0; i <= (anchor_w_ - 1); i++) {
-            for (int j = 0; j <= (anchor_h_ - 1); j++) {
-                int baseidx = (i + j * anchor_w_) * 2;
-                flow_(baseidx) = i * anchor_step_;
-                flow_(baseidx + 1) = j * anchor_step_;
-            }
-        }
-    }
-
-    Eigen::Vector2d QueryFlow(int i, int j) const {
-        int baseidx = (i + j * anchor_w_) * 2;
-        // exceptional case: quried anchor index is out of pre-defined space
-        if (baseidx < 0 || baseidx > anchor_w_ * anchor_h_ * 2)
-            return Eigen::Vector2d(0.0, 0.0);
-        else
-            return Eigen::Vector2d(flow_(baseidx), flow_(baseidx + 1));
-    }
-
-    Eigen::Vector2d GetImageWarpingField(double u, double v) const {
-        int i = (int)(u / anchor_step_);
-        int j = (int)(v / anchor_step_);
-        double p = (u - i * anchor_step_) / anchor_step_;
-        double q = (v - j * anchor_step_) / anchor_step_;
-        return (1 - p) * (1 - q) * QueryFlow(i, j)
-            + (1 - p) * (q)* QueryFlow(i, j + 1)
-            + (p)* (1 - q) * QueryFlow(i + 1, j)
-            + (p)* (q)* QueryFlow(i + 1, j + 1);
-    }
-
-public:
-    Eigen::VectorXd flow_;
-    int anchor_w_, anchor_h_;
-    double anchor_step_;
-};
 
 const double IMAGE_BOUNDARY_MARGIN = 10;
 

--- a/src/Core/ColorMap/ColorMapOptimization.h
+++ b/src/Core/ColorMap/ColorMapOptimization.h
@@ -80,7 +80,7 @@ public:
 /// Color Map Optimization for 3D Reconstruction with Consumer Depth Cameras,
 /// SIGGRAPH 2014
 void ColorMapOptimization(TriangleMesh& mesh,
-        const std::vector<RGBDImage>& imgs_rgbd,
+        const std::vector<std::shared_ptr<RGBDImage>>& imgs_rgbd,
         PinholeCameraTrajectory& camera,
         const ColorMapOptimizationOption& option =
         ColorMapOptimizationOption());

--- a/src/Core/ColorMap/ColorMapOptimization.h
+++ b/src/Core/ColorMap/ColorMapOptimization.h
@@ -46,7 +46,8 @@ public:
             double maximum_allowable_depth = 2.5,
             double depth_threshold_for_visiblity_check = 0.03,
             double depth_threshold_for_discontinuity_check = 0.1,
-            int half_dilation_kernel_size_for_discontinuity_map = 3) :
+            int half_dilation_kernel_size_for_discontinuity_map = 3,
+            int image_boundary_margin = 10) :
             non_rigid_camera_coordinate_(non_rigid_camera_coordinate),
             number_of_vertical_anchors_(number_of_vertical_anchors),
             non_rigid_anchor_point_weight_(non_rigid_anchor_point_weight),
@@ -57,7 +58,9 @@ public:
             depth_threshold_for_discontinuity_check_(
             depth_threshold_for_discontinuity_check),
             half_dilation_kernel_size_for_discontinuity_map_(
-            half_dilation_kernel_size_for_discontinuity_map) {}
+            half_dilation_kernel_size_for_discontinuity_map),
+            image_boundary_margin_(
+            image_boundary_margin) {}
 	~ColorMapOptimizationOption() {}
 
 public:
@@ -69,6 +72,7 @@ public:
     double depth_threshold_for_visiblity_check_;
     double depth_threshold_for_discontinuity_check_;
     int half_dilation_kernel_size_for_discontinuity_map_;
+    int image_boundary_margin_;
 };
 
 /// This is implementation of following paper

--- a/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
+++ b/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
@@ -26,13 +26,17 @@
 
 #include "ColorMapOptimizationJacobian.h"
 
+#include <Core/ColorMap/ImageWarpingField.h>
+#include <Core/ColorMap/EigenHelperForNonRigidOptimization.h>
 #include <Core/Geometry/Image.h>
 #include <Core/Geometry/TriangleMesh.h>
+
+#include <iostream>
 
 namespace open3d {
 
 void ColorMapOptimizationJacobian::ComputeJacobianAndResidualRigid(
-        int row, std::vector<Eigen::Vector6d> &J_r, std::vector<double> &r,
+        int row, Eigen::Vector6d &J_r, double &r,
         const TriangleMesh& mesh,
         const std::vector<double>& proxy_intensity,
         const std::shared_ptr<Image>& images_gray,
@@ -43,10 +47,8 @@ void ColorMapOptimizationJacobian::ComputeJacobianAndResidualRigid(
         const std::vector<int>& visiblity_image_to_vertex,
         const int image_boundary_margin)
 {
-    J_r.resize(1);
-    r.resize(1);
-    J_r[0].setZero();
-    r[0] = 0;
+    J_r.setZero();
+    r = 0;
     int vid = visiblity_image_to_vertex[row];
     Eigen::Vector3d x = mesh.vertices_[vid];
     Eigen::Vector4d g = extrinsic * Eigen::Vector4d(x(0), x(1), x(2), 1);
@@ -65,13 +67,103 @@ void ColorMapOptimizationJacobian::ComputeJacobianAndResidualRigid(
     double v0 = dIdx * intrinsic(0, 0) * invz;
     double v1 = dIdy * intrinsic(1, 1) * invz;
     double v2 = -(v0 * g(0) + v1 * g(1)) * invz;
-    J_r[0](0) = (-g(2) * v1 + g(1) * v2);
-    J_r[0](1) = (g(2) * v0 - g(0) * v2);
-    J_r[0](2) = (-g(1) * v0 + g(0) * v1);
-    J_r[0](3) = v0;
-    J_r[0](4) = v1;
-    J_r[0](5) = v2;
-    r[0] = (gray - proxy_intensity[vid]);
+    J_r(0) = (-g(2) * v1 + g(1) * v2);
+    J_r(1) = (g(2) * v0 - g(0) * v2);
+    J_r(2) = (-g(1) * v0 + g(0) * v1);
+    J_r(3) = v0;
+    J_r(4) = v1;
+    J_r(5) = v2;
+    r = (gray - proxy_intensity[vid]);
+}
+
+void ColorMapOptimizationJacobian::ComputeJacobianAndResidualNonRigid(
+        int row, Eigen::Vector14d &J_r, double &r, Eigen::Vector14d &pattern,
+        const TriangleMesh& mesh,
+        const std::vector<double>& proxy_intensity,
+        const std::shared_ptr<Image>& images_gray,
+        const std::shared_ptr<Image>& images_dx,
+        const std::shared_ptr<Image>& images_dy,
+        const ImageWarpingField& warping_fields,
+        const ImageWarpingField& warping_fields_init,
+        const Eigen::Matrix4d &intrinsic,
+        const Eigen::Matrix4d &extrinsic,
+        const std::vector<int>& visiblity_image_to_vertex,
+        const int image_boundary_margin)
+{
+    J_r.setZero();
+    pattern.setZero();
+    r = 0;
+    int anchor_w = warping_fields.anchor_w_;
+    int anchor_step = warping_fields.anchor_step_;
+    int vid = visiblity_image_to_vertex[row];
+    Eigen::Vector3d V = mesh.vertices_[vid];
+    Eigen::Vector4d G = extrinsic * Eigen::Vector4d(V(0), V(1), V(2), 1);
+    Eigen::Vector4d L = intrinsic * G;
+    double u = L(0) / L(2);
+    double v = L(1) / L(2);
+    int ii = (int)(u / anchor_step);
+    int jj = (int)(v / anchor_step);
+    double p = (u - ii * anchor_step) / anchor_step;
+    double q = (v - jj * anchor_step) / anchor_step;
+    Eigen::Vector2d grids[4] = {
+        warping_fields.QueryFlow(ii, jj),
+        warping_fields.QueryFlow(ii, jj + 1),
+        warping_fields.QueryFlow(ii + 1, jj),
+        warping_fields.QueryFlow(ii + 1, jj + 1),
+    };
+    Eigen::Vector2d uuvv = (1 - p) * (1 - q) * grids[0]
+        + (1 - p) * (q)* grids[1]
+        + (p)* (1 - q) * grids[2]
+        + (p)* (q)* grids[3];
+    double uu = uuvv(0);
+    double vv = uuvv(1);
+    if (!images_gray->TestImageBoundary(uu, vv,
+            image_boundary_margin))
+        return;
+    bool valid; double gray, dIdfx, dIdfy;
+    std::tie(valid, gray) = images_gray->FloatValueAt(uu, vv);
+    std::tie(valid, dIdfx) = images_dx->FloatValueAt(uu, vv);
+    std::tie(valid, dIdfy) = images_dy->FloatValueAt(uu, vv);
+    Eigen::Vector2d dIdf(dIdfx, dIdfy);
+    Eigen::Vector2d dfdx = ((grids[2] - grids[0]) * (1 - q) +
+            (grids[3] - grids[1]) * q) / anchor_step;
+    Eigen::Vector2d dfdy = ((grids[1] - grids[0]) * (1 - p) +
+            (grids[3] - grids[2]) * p) / anchor_step;
+    double dIdx = dIdf.dot(dfdx);
+    double dIdy = dIdf.dot(dfdy);
+    double invz = 1. / G(2);
+    double v0 = dIdx * intrinsic(0, 0) * invz;
+    double v1 = dIdy * intrinsic(1, 1) * invz;
+    double v2 = -(v0 * G(0) + v1 * G(1)) * invz;
+    J_r(0) = -G(2) * v1 + G(1) * v2;
+    J_r(1) = G(2) * v0 - G(0) * v2;
+    J_r(2) = -G(1) * v0 + G(0) * v1;
+    J_r(3) = v0;
+    J_r(4) = v1;
+    J_r(5) = v2;
+    J_r(6) = dIdf(0) * (1 - p) * (1 - q);
+    J_r(7) = dIdf(1) * (1 - p) * (1 - q);
+    J_r(8) = dIdf(0) * (1 - p) * (q);
+    J_r(9) = dIdf(1) * (1 - p) * (q);
+    J_r(10) = dIdf(0) * (p) * (1 - q);
+    J_r(11) = dIdf(1) * (p) * (1 - q);
+    J_r(12) = dIdf(0) * (p) * (q);
+    J_r(13) = dIdf(1) * (p) * (q);
+    pattern(0) = 0;
+    pattern(1) = 1;
+    pattern(2) = 2;
+    pattern(3) = 3;
+    pattern(4) = 4;
+    pattern(5) = 5;
+    pattern(6) = 6 + (ii + jj * anchor_w) * 2;
+    pattern(7) = 6 + (ii + jj * anchor_w) * 2 + 1;
+    pattern(8) = 6 + (ii + (jj + 1) * anchor_w) * 2;
+    pattern(9) = 6 + (ii + (jj + 1) * anchor_w) * 2 + 1;
+    pattern(10) = 6 + ((ii + 1) + jj * anchor_w) * 2;
+    pattern(11) = 6 + ((ii + 1) + jj * anchor_w) * 2 + 1;
+    pattern(12) = 6 + ((ii + 1) + (jj + 1) * anchor_w) * 2;
+    pattern(13) = 6 + ((ii + 1) + (jj + 1) * anchor_w) * 2 + 1;
+    r = (gray - proxy_intensity[vid]);
 }
 
 }    // namespace open3d

--- a/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
+++ b/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
@@ -31,8 +31,6 @@
 #include <Core/Geometry/Image.h>
 #include <Core/Geometry/TriangleMesh.h>
 
-#include <iostream>
-
 namespace open3d {
 
 void ColorMapOptimizationJacobian::ComputeJacobianAndResidualRigid(

--- a/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
+++ b/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
@@ -1,0 +1,77 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "ColorMapOptimizationJacobian.h"
+
+#include <Core/Geometry/Image.h>
+#include <Core/Geometry/TriangleMesh.h>
+
+namespace open3d {
+
+void ColorMapOptimizationJacobian::ComputeJacobianAndResidualRigid(
+        int row, std::vector<Eigen::Vector6d> &J_r, std::vector<double> &r,
+        const TriangleMesh& mesh,
+        const std::vector<double>& proxy_intensity,
+        const std::shared_ptr<Image>& images_gray,
+        const std::shared_ptr<Image>& images_dx,
+        const std::shared_ptr<Image>& images_dy,
+        const Eigen::Matrix4d &intrinsic,
+        const Eigen::Matrix4d &extrinsic,
+        const std::vector<int>& visiblity_image_to_vertex,
+        const int image_boundary_margin)
+{
+    J_r.resize(1);
+    r.resize(1);
+    J_r[0].setZero();
+    r[0] = 0;
+    int vid = visiblity_image_to_vertex[row];
+    Eigen::Vector3d x = mesh.vertices_[vid];
+    Eigen::Vector4d g = extrinsic * Eigen::Vector4d(x(0), x(1), x(2), 1);
+    Eigen::Vector4d uv = intrinsic * g;
+    double u = uv(0) / uv(2);
+    double v = uv(1) / uv(2);
+    if (!images_gray->TestImageBoundary(u, v, image_boundary_margin))
+        return;
+    bool valid; double gray, dIdx, dIdy;
+    std::tie(valid, gray) = images_gray->FloatValueAt(u, v);
+    std::tie(valid, dIdx) = images_dx->FloatValueAt(u, v);
+    std::tie(valid, dIdy) = images_dy->FloatValueAt(u, v);
+    if (gray == -1.0)
+        return;
+    double invz = 1. / g(2);
+    double v0 = dIdx * intrinsic(0, 0) * invz;
+    double v1 = dIdy * intrinsic(1, 1) * invz;
+    double v2 = -(v0 * g(0) + v1 * g(1)) * invz;
+    J_r[0](0) = (-g(2) * v1 + g(1) * v2);
+    J_r[0](1) = (g(2) * v0 - g(0) * v2);
+    J_r[0](2) = (-g(1) * v0 + g(0) * v1);
+    J_r[0](3) = v0;
+    J_r[0](4) = v1;
+    J_r[0](5) = v2;
+    r[0] = (gray - proxy_intensity[vid]);
+}
+
+}    // namespace open3d

--- a/src/Core/ColorMap/ColorMapOptimizationJacobian.h
+++ b/src/Core/ColorMap/ColorMapOptimizationJacobian.h
@@ -1,0 +1,64 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <vector>
+#include <Core/Utility/Eigen.h>
+
+namespace open3d {
+    
+class Image;
+    
+class TriangleMesh;
+
+/// Base class that computes Jacobian from two RGB-D images
+class ColorMapOptimizationJacobian
+{
+public:
+    ColorMapOptimizationJacobian() {}
+//    virtual ColorMapOptimizationJacobian() {}
+    
+public:
+    /// Function to compute i-th row of J and r
+    /// the vector form of J_r is basically 6x1 matrix, but it can be
+    /// easily extendable to 6xn matrix.
+    /// See RGBDOdometryJacobianFromHybridTerm for this case.
+//    virtual void ComputeJacobianAndResidual() const = 0;
+    void ComputeJacobianAndResidualRigid(
+            int row, std::vector<Eigen::Vector6d> &J_r, std::vector<double> &r,
+            const TriangleMesh& mesh,
+            const std::vector<double>& proxy_intensity,
+            const std::shared_ptr<Image>& images_gray,
+            const std::shared_ptr<Image>& images_dx,
+            const std::shared_ptr<Image>& images_dy,
+            const Eigen::Matrix4d &intrinsic,
+            const Eigen::Matrix4d &extrinsic,
+            const std::vector<int>& visiblity_image_to_vertex,
+            const int image_boundary_margin);
+};
+    
+}	// namespace open3d

--- a/src/Core/ColorMap/ColorMapOptimizationJacobian.h
+++ b/src/Core/ColorMap/ColorMapOptimizationJacobian.h
@@ -27,12 +27,15 @@
 #pragma once
 
 #include <vector>
+#include <Core/ColorMap/EigenHelperForNonRigidOptimization.h>
 #include <Core/Utility/Eigen.h>
 
 namespace open3d {
-    
+
 class Image;
-    
+
+class ImageWarpingField;
+
 class TriangleMesh;
 
 /// Base class that computes Jacobian from two RGB-D images
@@ -41,7 +44,7 @@ class ColorMapOptimizationJacobian
 public:
     ColorMapOptimizationJacobian() {}
 //    virtual ColorMapOptimizationJacobian() {}
-    
+
 public:
     /// Function to compute i-th row of J and r
     /// the vector form of J_r is basically 6x1 matrix, but it can be
@@ -49,7 +52,7 @@ public:
     /// See RGBDOdometryJacobianFromHybridTerm for this case.
 //    virtual void ComputeJacobianAndResidual() const = 0;
     void ComputeJacobianAndResidualRigid(
-            int row, std::vector<Eigen::Vector6d> &J_r, std::vector<double> &r,
+            int row, Eigen::Vector6d &J_r, double &r,
             const TriangleMesh& mesh,
             const std::vector<double>& proxy_intensity,
             const std::shared_ptr<Image>& images_gray,
@@ -59,6 +62,21 @@ public:
             const Eigen::Matrix4d &extrinsic,
             const std::vector<int>& visiblity_image_to_vertex,
             const int image_boundary_margin);
+
+    void ComputeJacobianAndResidualNonRigid(
+            int row, Eigen::Vector14d &J_r, double &r,
+            Eigen::Vector14d &pattern,
+            const TriangleMesh& mesh,
+            const std::vector<double>& proxy_intensity,
+            const std::shared_ptr<Image>& images_gray,
+            const std::shared_ptr<Image>& images_dx,
+            const std::shared_ptr<Image>& images_dy,
+            const ImageWarpingField& warping_fields,
+            const ImageWarpingField& warping_fields_init,
+            const Eigen::Matrix4d &intrinsic,
+            const Eigen::Matrix4d &extrinsic,
+            const std::vector<int>& visiblity_image_to_vertex,
+            const int image_boundary_margin);
 };
-    
+
 }	// namespace open3d

--- a/src/Core/ColorMap/EigenHelperForNonRigidOptimization.cpp
+++ b/src/Core/ColorMap/EigenHelperForNonRigidOptimization.cpp
@@ -1,0 +1,95 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "EigenHelperForNonRigidOptimization.h"
+
+#include <Core/Utility/Console.h>
+
+namespace open3d{
+
+// This function make JTJ and JTr
+// The main difference between this and other helper functions in Eigen
+// is that this function can take multiplication pattern
+template<typename VecInType, typename MatOutType, typename VecOutType>
+std::tuple<MatOutType, VecOutType, double> ComputeJTJandJTr(
+        std::function<void(int, VecInType &, double &, VecInType &)> f,
+        int iteration_num, int nonrigidval, bool verbose/*=true*/)
+{
+    MatOutType JTJ(6 + nonrigidval, 6 + nonrigidval);
+    VecOutType JTr(6 + nonrigidval);
+    double r2_sum = 0.0;
+    JTJ.setZero();
+    JTr.setZero();
+#ifdef _OPENMP
+#pragma omp parallel
+    {
+#endif
+        MatOutType JTJ_private(6 + nonrigidval, 6 + nonrigidval);
+        VecOutType JTr_private(6 + nonrigidval);
+        double r2_sum_private = 0.0;
+        JTJ_private.setZero();
+        JTr_private.setZero();
+        VecInType J_r;
+        VecInType pattern;
+        double r;
+#ifdef _OPENMP
+#pragma omp for nowait
+#endif
+        for (int i = 0; i < iteration_num; i++) {
+            f(i, J_r, r, pattern);
+            for (int x = 0; x < J_r.size(); x++) {
+                for (int y = 0; y < J_r.size(); y++) {
+                    JTJ_private(pattern[x], pattern[y]) += J_r[x] * J_r[y];
+                }
+            }
+            for (int x = 0; x < J_r.size(); x++) {
+                JTr_private(pattern[x]) += r * J_r[x];
+            }
+            r2_sum_private += r * r;
+        }
+#ifdef _OPENMP
+#pragma omp critical
+        {
+#endif
+            JTJ += JTJ_private;
+            JTr += JTr_private;
+            r2_sum += r2_sum_private;
+#ifdef _OPENMP
+        }
+    }
+#endif
+    if (verbose) {
+        PrintDebug("Residual : %.2e (# of elements : %d)\n",
+                r2_sum/(double)iteration_num, iteration_num);
+    }
+    return std::make_tuple(std::move(JTJ), std::move(JTr), r2_sum);
+}
+
+template std::tuple<Eigen::MatrixXd, Eigen::VectorXd, double> ComputeJTJandJTr(
+        std::function<void(int, Eigen::Vector14d &, double &, Eigen::Vector14d &)> f,
+        int iteration_num, int nonrigidval, bool verbose);
+
+}    // namespace open3d

--- a/src/Core/ColorMap/EigenHelperForNonRigidOptimization.h
+++ b/src/Core/ColorMap/EigenHelperForNonRigidOptimization.h
@@ -24,24 +24,28 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include <Core/Geometry/Image.h>
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <Eigen/Core>
+
+namespace Eigen {
+
+typedef Eigen::Matrix<double, 14, 14> Matrix14d;
+typedef Eigen::Matrix<double, 14, 1> Vector14d;
+
+}    // namespace Eigen
 
 namespace open3d {
 
-class ImageWarpingField {
+/// Function to compute JTJ and Jtr
+/// Input: function pointer f and total number of rows of Jacobian matrix
+/// Output: JTJ, JTr, sum of r^2
+/// Note: f takes index of row, and outputs corresponding residual and row vector.
+template<typename VecInType, typename MatOutType, typename VecOutType>
+std::tuple<MatOutType, VecOutType, double> ComputeJTJandJTr(
+        std::function<void(int, VecInType &, double &, VecInType &)> f,
+        int iteration_num, int nonrigidval, bool verbose = true);
 
-public:
-    ImageWarpingField (int width, int height, int number_of_vertical_anchors);
-    void InitializeWarpingFields(int width, int height,
-            int number_of_vertical_anchors);
-    Eigen::Vector2d QueryFlow(int i, int j) const;
-    Eigen::Vector2d GetImageWarpingField(double u, double v) const;
-
-public:
-    Eigen::VectorXd flow_;
-    int anchor_w_;
-    int anchor_h_;
-    double anchor_step_;
-};
-
-}	// namespace open3d
+}    // namespace open3d

--- a/src/Core/ColorMap/ImageWarpingField.cpp
+++ b/src/Core/ColorMap/ImageWarpingField.cpp
@@ -1,0 +1,72 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "ImageWarpingField.h"
+
+namespace open3d {
+
+ImageWarpingField::ImageWarpingField (
+        int width, int height, int number_of_vertical_anchors) {
+    InitializeWarpingFields(width, height, number_of_vertical_anchors);
+}
+
+void ImageWarpingField::InitializeWarpingFields(int width, int height,
+        int number_of_vertical_anchors) {
+    anchor_h_ = number_of_vertical_anchors;
+    anchor_step_ = double(height) / (anchor_h_ - 1);
+    anchor_w_ = int(std::ceil(double(width) / anchor_step_) + 1);
+    flow_ = Eigen::VectorXd(anchor_w_ * anchor_h_ * 2);
+    for (int i = 0; i <= (anchor_w_ - 1); i++) {
+        for (int j = 0; j <= (anchor_h_ - 1); j++) {
+            int baseidx = (i + j * anchor_w_) * 2;
+            flow_(baseidx) = i * anchor_step_;
+            flow_(baseidx + 1) = j * anchor_step_;
+        }
+    }
+}
+
+Eigen::Vector2d ImageWarpingField::QueryFlow(int i, int j) const {
+    int baseidx = (i + j * anchor_w_) * 2;
+    // exceptional case: quried anchor index is out of pre-defined space
+    if (baseidx < 0 || baseidx > anchor_w_ * anchor_h_ * 2)
+        return Eigen::Vector2d(0.0, 0.0);
+    else
+        return Eigen::Vector2d(flow_(baseidx), flow_(baseidx + 1));
+}
+
+Eigen::Vector2d ImageWarpingField::GetImageWarpingField(
+        double u, double v) const {
+    int i = (int)(u / anchor_step_);
+    int j = (int)(v / anchor_step_);
+    double p = (u - i * anchor_step_) / anchor_step_;
+    double q = (v - j * anchor_step_) / anchor_step_;
+    return (1 - p) * (1 - q) * QueryFlow(i, j)
+        + (1 - p) * (q)* QueryFlow(i, j + 1)
+        + (p)* (1 - q) * QueryFlow(i + 1, j)
+        + (p)* (q)* QueryFlow(i + 1, j + 1);
+}
+
+}	// namespace open3d

--- a/src/Core/ColorMap/ImageWarpingField.h
+++ b/src/Core/ColorMap/ImageWarpingField.h
@@ -24,6 +24,8 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#pragma once
+
 #include <Core/Geometry/Image.h>
 
 namespace open3d {

--- a/src/Core/ColorMap/ImageWarpingField.h
+++ b/src/Core/ColorMap/ImageWarpingField.h
@@ -1,0 +1,46 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <Core/Geometry/Image.h>
+
+namespace open3d {
+
+class ImageWarpingField {
+
+public:
+    ImageWarpingField (int width, int height, int number_of_vertical_anchors);
+    void InitializeWarpingFields(int width, int height,
+            int number_of_vertical_anchors);
+    Eigen::Vector2d QueryFlow(int i, int j) const;
+    Eigen::Vector2d GetImageWarpingField(double u, double v) const;
+
+public:
+    Eigen::VectorXd flow_;
+    int anchor_w_, anchor_h_;
+    double anchor_step_;
+};
+
+}	// namespace open3d

--- a/src/Core/ColorMap/TriangleMeshAndImageUtilities.cpp
+++ b/src/Core/ColorMap/TriangleMeshAndImageUtilities.cpp
@@ -1,0 +1,297 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "TriangleMeshAndImageUtilities.h"
+
+#include <Core/Camera/PinholeCameraTrajectory.h>
+#include <Core/ColorMap/ImageWarpingField.h>
+#include <Core/ColorMap/ColorMapOptimization.h>
+#include <Core/Geometry/Image.h>
+#include <Core/Geometry/RGBDImage.h>
+#include <Core/Geometry/TriangleMesh.h>
+
+namespace open3d {
+
+//const double IMAGE_BOUNDARY_MARGIN = 10;
+
+inline std::tuple<float, float, float> Project3DPointAndGetUVDepth(
+        const Eigen::Vector3d X,
+        const PinholeCameraTrajectory& camera, int camid)
+{
+    std::pair<double, double> f =
+            camera.parameters_[camid].intrinsic_.GetFocalLength();
+    std::pair<double, double> p =
+            camera.parameters_[camid].intrinsic_.GetPrincipalPoint();
+    Eigen::Vector4d Vt = camera.parameters_[camid].extrinsic_ *
+            Eigen::Vector4d(X(0), X(1), X(2), 1);
+    float u = float((Vt(0) * f.first) / Vt(2) + p.first);
+    float v = float((Vt(1) * f.second) / Vt(2) + p.second);
+    float z = float(Vt(2));
+    return std::make_tuple(u, v, z);
+}
+
+std::tuple<std::vector<std::vector<int>>, std::vector<std::vector<int>>>
+        MakeVertexAndImageVisibility(const TriangleMesh& mesh,
+        const std::vector<RGBDImage>& images_rgbd,
+        const std::vector<std::shared_ptr<Image>>& images_mask,
+        const PinholeCameraTrajectory& camera,
+        const ColorMapOptimizationOption& option)
+{
+    auto n_camera = camera.parameters_.size();
+    auto n_vertex = mesh.vertices_.size();
+    std::vector<std::vector<int>> visiblity_vertex_to_image;
+    std::vector<std::vector<int>> visiblity_image_to_vertex;
+    visiblity_vertex_to_image.resize(n_vertex);
+    visiblity_image_to_vertex.resize(n_camera);
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (int c = 0; c < n_camera; c++) {
+        int viscnt = 0;
+        for (int vertex_id = 0; vertex_id < n_vertex; vertex_id++) {
+            Eigen::Vector3d X = mesh.vertices_[vertex_id];
+            float u, v, d;
+            std::tie(u, v, d) = Project3DPointAndGetUVDepth(X, camera, c);
+            int u_d = int(round(u)), v_d = int(round(v));
+            if (d < 0.0 || !images_rgbd[c].depth_.TestImageBoundary(u_d, v_d))
+                continue;
+            float d_sensor = *PointerAt<float>(images_rgbd[c].depth_, u_d, v_d);
+            if (d_sensor > option.maximum_allowable_depth_)
+                continue;
+            if (*PointerAt<unsigned char>(*images_mask[c], u_d, v_d) == 255)
+                continue;
+            if (std::fabs(d - d_sensor) <
+                    option.depth_threshold_for_visiblity_check_) {
+#ifdef _OPENMP
+#pragma omp critical
+#endif
+                {
+                    visiblity_vertex_to_image[vertex_id].push_back(c);
+                    visiblity_image_to_vertex[c].push_back(vertex_id);
+                    viscnt++;
+                }
+            }
+        }
+        PrintDebug("[cam %d] %.5f percents are visible\n",
+                c, double(viscnt) / n_vertex * 100); fflush(stdout);
+    }
+    return std::move(std::make_tuple(
+            visiblity_vertex_to_image, visiblity_image_to_vertex));
+}
+
+template<typename T>
+std::tuple<bool, T> QueryImageIntensity(
+        const Image& img, const Eigen::Vector3d& V,
+        const PinholeCameraTrajectory& camera, int camid,
+        int ch/*= -1*/, int image_boundary_margin/*= 10*/)
+{
+    float u, v, depth;
+    std::tie(u, v, depth) = Project3DPointAndGetUVDepth(V, camera, camid);
+    if (img.TestImageBoundary(u, v, image_boundary_margin)) {
+        int u_round = int(round(u));
+        int v_round = int(round(v));
+        if (ch == -1) {
+            return std::make_tuple(true,
+                    *PointerAt<T>(img, u_round, v_round));
+        } else {
+            return std::make_tuple(true,
+                    *PointerAt<T>(img, u_round, v_round, ch));
+        }
+    } else {
+        return std::make_tuple(false, 0);
+    }
+}
+
+template<typename T>
+std::tuple<bool, T> QueryImageIntensity(
+        const Image& img, const ImageWarpingField& field,
+        const Eigen::Vector3d& V,
+        const PinholeCameraTrajectory& camera, int camid,
+        int ch/*= -1*/, int image_boundary_margin/*= 10*/)
+{
+    float u, v, depth;
+    std::tie(u, v, depth) = Project3DPointAndGetUVDepth(V, camera, camid);
+    if (img.TestImageBoundary(u, v, image_boundary_margin)) {
+        Eigen::Vector2d uv_shift = field.GetImageWarpingField(u, v);
+        if (img.TestImageBoundary(uv_shift(0), uv_shift(1),
+                image_boundary_margin)) {
+            int u_shift = int(round(uv_shift(0)));
+            int v_shift = int(round(uv_shift(1)));
+            if (ch == -1) {
+                return std::make_tuple(true,
+                        *PointerAt<T>(img, u_shift, v_shift));
+            } else {
+                return std::make_tuple(true,
+                        *PointerAt<T>(img, u_shift, v_shift, ch));
+            }
+        }
+    }
+    return std::make_tuple(false, 0);
+}
+
+void SetProxyIntensityForVertex(const TriangleMesh& mesh,
+        const std::vector<std::shared_ptr<Image>>& images_gray,
+        const std::vector<ImageWarpingField>& warping_field,
+        const PinholeCameraTrajectory& camera,
+        const std::vector<std::vector<int>>& visiblity_vertex_to_image,
+        std::vector<double>& proxy_intensity)
+{
+    auto n_vertex = mesh.vertices_.size();
+    proxy_intensity.resize(n_vertex);
+
+#pragma omp parallel for schedule(static)
+    for (auto i = 0; i < n_vertex; i++) {
+        proxy_intensity[i] = 0.0;
+        float sum = 0.0;
+        for (auto iter = 0; iter < visiblity_vertex_to_image[i].size();
+                iter++) {
+            int j = visiblity_vertex_to_image[i][iter];
+            float gray;
+            bool valid = false;
+            std::tie(valid, gray) = QueryImageIntensity<float>(
+                    *images_gray[j], warping_field[j],
+                    mesh.vertices_[i], camera, j);
+            if (valid) {
+                sum += 1.0;
+                proxy_intensity[i] += gray;
+            }
+        }
+        if (sum > 0) {
+            proxy_intensity[i] /= sum;
+        }
+    }
+}
+
+void SetProxyIntensityForVertex(const TriangleMesh& mesh,
+        const std::vector<std::shared_ptr<Image>>& images_gray,
+        const PinholeCameraTrajectory& camera,
+        const std::vector<std::vector<int>>& visiblity_vertex_to_image,
+        std::vector<double>& proxy_intensity)
+{
+    auto n_vertex = mesh.vertices_.size();
+    proxy_intensity.resize(n_vertex);
+
+#pragma omp parallel for num_threads( 8 )
+    for (auto i = 0; i < n_vertex; i++) {
+        proxy_intensity[i] = 0.0;
+        float sum = 0.0;
+        for (auto iter = 0; iter < visiblity_vertex_to_image[i].size();
+                iter++) {
+            int j = visiblity_vertex_to_image[i][iter];
+            float gray;
+            bool valid = false;
+            std::tie(valid, gray) = QueryImageIntensity<float>(
+                    *images_gray[j], mesh.vertices_[i], camera, j);
+            if (valid) {
+                sum += 1.0;
+                proxy_intensity[i] += gray;
+            }
+        }
+        if (sum > 0) {
+            proxy_intensity[i] /= sum;
+        }
+    }
+}
+
+void SetGeometryColorAverage(TriangleMesh& mesh,
+        const std::vector<RGBDImage>& images_rgbd,
+        const PinholeCameraTrajectory& camera,
+        const std::vector<std::vector<int>>& visiblity_vertex_to_image)
+{
+    auto n_vertex = mesh.vertices_.size();
+    mesh.vertex_colors_.clear();
+    mesh.vertex_colors_.resize(n_vertex);
+#pragma omp parallel for schedule(static)
+    for (int i = 0; i < n_vertex; i++) {
+        mesh.vertex_colors_[i] = Eigen::Vector3d::Zero();
+        double sum = 0.0;
+        for (auto iter = 0; iter < visiblity_vertex_to_image[i].size();
+                iter++) {
+            int j = visiblity_vertex_to_image[i][iter];
+            unsigned char r_temp, g_temp, b_temp;
+            bool valid = false;
+            std::tie(valid, r_temp) = QueryImageIntensity<unsigned char>(
+                    images_rgbd[j].color_, mesh.vertices_[i], camera, j, 0);
+            std::tie(valid, g_temp) = QueryImageIntensity<unsigned char>(
+                    images_rgbd[j].color_, mesh.vertices_[i], camera, j, 1);
+            std::tie(valid, b_temp) = QueryImageIntensity<unsigned char>(
+                    images_rgbd[j].color_, mesh.vertices_[i], camera, j, 2);
+            float r = (float)r_temp / 255.0f;
+            float g = (float)g_temp / 255.0f;
+            float b = (float)b_temp / 255.0f;
+            if (valid) {
+                mesh.vertex_colors_[i] += Eigen::Vector3d(r, g, b);
+                sum += 1.0;
+            }
+        }
+        if (sum > 0.0) {
+            mesh.vertex_colors_[i] /= sum;
+        }
+    }
+}
+
+void SetGeometryColorAverage(TriangleMesh& mesh,
+        const std::vector<RGBDImage>& images_rgbd,
+        const std::vector<ImageWarpingField>& warping_fields,
+        const PinholeCameraTrajectory& camera,
+        const std::vector<std::vector<int>>& visiblity_vertex_to_image)
+{
+    auto n_vertex = mesh.vertices_.size();
+    mesh.vertex_colors_.clear();
+    mesh.vertex_colors_.resize(n_vertex);
+#pragma omp parallel for schedule(static)
+    for (int i = 0; i < n_vertex; i++) {
+        mesh.vertex_colors_[i] = Eigen::Vector3d::Zero();
+        double sum = 0.0;
+        for (auto iter = 0; iter < visiblity_vertex_to_image[i].size();
+                iter++) {
+            int j = visiblity_vertex_to_image[i][iter];
+            unsigned char r_temp, g_temp, b_temp;
+            bool valid = false;
+            std::tie(valid, r_temp) = QueryImageIntensity<unsigned char>(
+                    images_rgbd[j].color_, warping_fields[j],
+                    mesh.vertices_[i], camera, j, 0);
+            std::tie(valid, g_temp) = QueryImageIntensity<unsigned char>(
+                    images_rgbd[j].color_, warping_fields[j],
+                    mesh.vertices_[i], camera, j, 1);
+            std::tie(valid, b_temp) = QueryImageIntensity<unsigned char>(
+                    images_rgbd[j].color_, warping_fields[j],
+                    mesh.vertices_[i], camera, j, 2);
+            float r = (float)r_temp / 255.0f;
+            float g = (float)g_temp / 255.0f;
+            float b = (float)b_temp / 255.0f;
+            if (valid) {
+                mesh.vertex_colors_[i] += Eigen::Vector3d(r, g, b);
+                sum += 1.0;
+            }
+        }
+        if (sum > 0.0) {
+            mesh.vertex_colors_[i] /= sum;
+        }
+    }
+}
+
+}   // namespace open3d

--- a/src/Core/ColorMap/TriangleMeshAndImageUtilities.h
+++ b/src/Core/ColorMap/TriangleMeshAndImageUtilities.h
@@ -1,0 +1,89 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <vector>
+#include <Core/Utility/Eigen.h>
+
+namespace open3d {
+
+class Image;
+class RGBDImage;
+class TriangleMesh;
+class ImageWarpingField;
+class ColorMapOptimizationOption;
+class PinholeCameraTrajectory;
+
+inline std::tuple<float, float, float> Project3DPointAndGetUVDepth(
+        const Eigen::Vector3d X,
+        const PinholeCameraTrajectory& camera, int camid);
+
+std::tuple<std::vector<std::vector<int>>, std::vector<std::vector<int>>>
+        MakeVertexAndImageVisibility(const TriangleMesh& mesh,
+        const std::vector<RGBDImage>& images_rgbd,
+        const std::vector<std::shared_ptr<Image>>& images_mask,
+        const PinholeCameraTrajectory& camera,
+        const ColorMapOptimizationOption& option);
+
+template<typename T>
+std::tuple<bool, T> QueryImageIntensity(
+        const Image& img, const Eigen::Vector3d& V,
+        const PinholeCameraTrajectory& camera, int camid,
+        int ch = -1, int image_boundary_margin = 10);
+
+template<typename T>
+std::tuple<bool, T> QueryImageIntensity(
+        const Image& img, const ImageWarpingField& field,
+        const Eigen::Vector3d& V,
+        const PinholeCameraTrajectory& camera, int camid,
+        int ch = -1, int image_boundary_margin = 10);
+
+void SetProxyIntensityForVertex(const TriangleMesh& mesh,
+        const std::vector<std::shared_ptr<Image>>& images_gray,
+        const std::vector<ImageWarpingField>& warping_field,
+        const PinholeCameraTrajectory& camera,
+        const std::vector<std::vector<int>>& visiblity_vertex_to_image,
+        std::vector<double>& proxy_intensity);
+
+void SetProxyIntensityForVertex(const TriangleMesh& mesh,
+        const std::vector<std::shared_ptr<Image>>& images_gray,
+        const PinholeCameraTrajectory& camera,
+        const std::vector<std::vector<int>>& visiblity_vertex_to_image,
+        std::vector<double>& proxy_intensity);
+
+void SetGeometryColorAverage(TriangleMesh& mesh,
+        const std::vector<RGBDImage>& images_rgbd,
+        const PinholeCameraTrajectory& camera,
+        const std::vector<std::vector<int>>& visiblity_vertex_to_image);
+
+void SetGeometryColorAverage(TriangleMesh& mesh,
+        const std::vector<RGBDImage>& images_rgbd,
+        const std::vector<ImageWarpingField>& warping_fields,
+        const PinholeCameraTrajectory& camera,
+        const std::vector<std::vector<int>>& visiblity_vertex_to_image);
+
+}   // namespace open3d

--- a/src/Core/ColorMap/TriangleMeshAndImageUtilities.h
+++ b/src/Core/ColorMap/TriangleMeshAndImageUtilities.h
@@ -44,7 +44,7 @@ inline std::tuple<float, float, float> Project3DPointAndGetUVDepth(
 
 std::tuple<std::vector<std::vector<int>>, std::vector<std::vector<int>>>
         MakeVertexAndImageVisibility(const TriangleMesh& mesh,
-        const std::vector<RGBDImage>& images_rgbd,
+        const std::vector<std::shared_ptr<Image>>& images_rgbd,
         const std::vector<std::shared_ptr<Image>>& images_mask,
         const PinholeCameraTrajectory& camera,
         const ColorMapOptimizationOption& option);
@@ -76,12 +76,12 @@ void SetProxyIntensityForVertex(const TriangleMesh& mesh,
         std::vector<double>& proxy_intensity);
 
 void SetGeometryColorAverage(TriangleMesh& mesh,
-        const std::vector<RGBDImage>& images_rgbd,
+        const std::vector<std::shared_ptr<Image>>& images_rgbd,
         const PinholeCameraTrajectory& camera,
         const std::vector<std::vector<int>>& visiblity_vertex_to_image);
 
 void SetGeometryColorAverage(TriangleMesh& mesh,
-        const std::vector<RGBDImage>& images_rgbd,
+        const std::vector<std::shared_ptr<Image>>& images_rgbd,
         const std::vector<ImageWarpingField>& warping_fields,
         const PinholeCameraTrajectory& camera,
         const std::vector<std::vector<int>>& visiblity_vertex_to_image);

--- a/src/Core/Geometry/DownSample.cpp
+++ b/src/Core/Geometry/DownSample.cpp
@@ -305,7 +305,6 @@ std::tuple<std::shared_ptr<PointCloud>,Eigen::MatrixXi> VoxelDownSampleAndTrace(
         PrintDebug("[VoxelDownSample] voxel_size <= 0.\n");
         return std::make_tuple(output, cubic_id);
     }
-    auto voxel_size3 = Eigen::Vector3d(voxel_size, voxel_size, voxel_size);
     // Note: this is different from VoxelDownSample.
     // It is for fixing coordinate for multiscale voxel space
     auto voxel_min_bound = min_bound;

--- a/src/Core/Geometry/Image.cpp
+++ b/src/Core/Geometry/Image.cpp
@@ -338,4 +338,43 @@ std::shared_ptr<Image> DilateImage(const Image &input,
     return output;
 }
 
+std::shared_ptr<Image> CreateDepthBoundaryMask(
+        const Image& depth_image_input,
+        double depth_threshold_for_discontinuity_check,
+        int half_dilation_kernel_size_for_discontinuity_map)
+{
+    auto depth_image = CreateFloatImageFromImage(depth_image_input); // necessary?
+    int width = depth_image->width_;
+    int height = depth_image->height_;
+    auto depth_image_gradient_dx = FilterImage(*depth_image,
+            Image::FilterType::Sobel3Dx);
+    auto depth_image_gradient_dy = FilterImage(*depth_image,
+            Image::FilterType::Sobel3Dy);
+    auto mask = std::make_shared<Image>();
+    mask->PrepareImage(width, height, 1, 1);
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (int v=0; v<height; v++) {
+        for (int u=0; u<width; u++) {
+            double dx = *PointerAt<float>(*depth_image_gradient_dx, u, v);
+            double dy = *PointerAt<float>(*depth_image_gradient_dy, u, v);
+            double mag = sqrt(dx * dx + dy * dy);
+            if (mag > depth_threshold_for_discontinuity_check) {
+                *PointerAt<unsigned char>(*mask, u, v) = 255;
+            } else {
+                *PointerAt<unsigned char>(*mask, u, v) = 0;
+            }
+        }
+    }
+    if (half_dilation_kernel_size_for_discontinuity_map >= 1) {
+        auto mask_dilated = DilateImage(*mask,
+        half_dilation_kernel_size_for_discontinuity_map);
+        return mask_dilated;
+    } else {
+        return mask;
+    }
+}
+
 }    // namespace open3d

--- a/src/Core/Geometry/Image.h
+++ b/src/Core/Geometry/Image.h
@@ -164,10 +164,18 @@ std::shared_ptr<Image> CreateImageFromFloatImage(const Image &input);
 /// Typedef and functions for ImagePyramid
 typedef std::vector<std::shared_ptr<Image>> ImagePyramid;
 
+/// Function to filter image pyramid
 ImagePyramid FilterImagePyramid(const ImagePyramid &input,
         Image::FilterType type);
 
+/// Function to create image pyramid
 ImagePyramid CreateImagePyramid(const Image& image,
         size_t num_of_levels, bool with_gaussian_filter = true);
+
+/// Function to create a depthmap boundary mask from depth image
+std::shared_ptr<Image> CreateDepthBoundaryMask(
+        const Image& depth_image_input,
+        double depth_threshold_for_discontinuity_check = 0.1,
+        int half_dilation_kernel_size_for_discontinuity_map = 3);
 
 }    // namespace open3d

--- a/src/Core/Odometry/Odometry.cpp
+++ b/src/Core/Odometry/Odometry.cpp
@@ -413,7 +413,8 @@ std::tuple<bool, Eigen::Matrix4d> DoSingleIteration(
     PrintDebug("Iter : %d, Level : %d, ", iter, level);
     Eigen::Matrix6d JTJ;
     Eigen::Vector6d JTr;
-    std::tie(JTJ, JTr) = ComputeJTJandJTr<Eigen::Matrix6d, Eigen::Vector6d>(
+    double r2;
+    std::tie(JTJ, JTr, r2) = ComputeJTJandJTr<Eigen::Matrix6d, Eigen::Vector6d>(
             f_lambda, corresps_count);
 
     bool is_success;

--- a/src/Core/Registration/ColoredICP.cpp
+++ b/src/Core/Registration/ColoredICP.cpp
@@ -189,7 +189,8 @@ Eigen::Matrix4d TransformationEstimationForColoredICP::ComputeTransformation(
 
     Eigen::Matrix6d JTJ;
     Eigen::Vector6d JTr;
-    std::tie(JTJ, JTr) = ComputeJTJandJTr<Eigen::Matrix6d, Eigen::Vector6d>(
+    double r2;
+    std::tie(JTJ, JTr, r2) = ComputeJTJandJTr<Eigen::Matrix6d, Eigen::Vector6d>(
             compute_jacobian_and_residual, (int)corres.size());
 
     bool is_success;

--- a/src/Core/Registration/TransformationEstimation.cpp
+++ b/src/Core/Registration/TransformationEstimation.cpp
@@ -91,7 +91,8 @@ Eigen::Matrix4d TransformationEstimationPointToPlane::ComputeTransformation(
 
     Eigen::Matrix6d JTJ;
     Eigen::Vector6d JTr;
-    std::tie(JTJ, JTr) = ComputeJTJandJTr<Eigen::Matrix6d, Eigen::Vector6d>(
+    double r2;
+    std::tie(JTJ, JTr, r2) = ComputeJTJandJTr<Eigen::Matrix6d, Eigen::Vector6d>(
             compute_jacobian_and_residual, (int)corres.size());
 
     bool is_success;

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -135,9 +135,9 @@ std::tuple<bool, std::vector<Eigen::Matrix4d>>
 }
 
 template<typename MatType, typename VecType>
-std::tuple<MatType, VecType> ComputeJTJandJTr(
+std::tuple<MatType, VecType, double> ComputeJTJandJTr(
         std::function<void(int, VecType &, double &)> f,
-        int iteration_num)
+        int iteration_num, bool verbose/*=true*/)
 {
     MatType JTJ;
     VecType JTr;
@@ -175,16 +175,17 @@ std::tuple<MatType, VecType> ComputeJTJandJTr(
         }
     }
 #endif
-    r2_sum /= (double)iteration_num;
-    PrintDebug("Residual : %.2e (# of elements : %d)\n", r2_sum,
-            iteration_num);
-    return std::make_tuple(std::move(JTJ), std::move(JTr));
+    if (verbose) {
+        PrintDebug("Residual : %.2e (# of elements : %d)\n",
+                r2_sum/(double)iteration_num, iteration_num);
+    }
+    return std::make_tuple(std::move(JTJ), std::move(JTr), r2_sum);
 }
 
 template<typename MatType, typename VecType>
-std::tuple<MatType, VecType> ComputeJTJandJTr(
+std::tuple<MatType, VecType, double> ComputeJTJandJTr(
         std::function<void(int, std::vector<VecType> &, std::vector<double> &)> f,
-        int iteration_num)
+        int iteration_num, bool verbose/*=true*/)
 {
     MatType JTJ;
     VecType JTr;
@@ -224,18 +225,19 @@ std::tuple<MatType, VecType> ComputeJTJandJTr(
         }
     }
 #endif
-    r2_sum /= (double)iteration_num;
-    PrintDebug("Residual : %.2e (# of elements : %d)\n", r2_sum,
-            iteration_num);
-    return std::make_tuple(std::move(JTJ), std::move(JTr));
+    if (verbose) {
+        PrintDebug("Residual : %.2e (# of elements : %d)\n",
+                r2_sum/(double)iteration_num, iteration_num);
+    }
+    return std::make_tuple(std::move(JTJ), std::move(JTr), r2_sum);
 }
 
-template std::tuple<Eigen::Matrix6d, Eigen::Vector6d> ComputeJTJandJTr(
+template std::tuple<Eigen::Matrix6d, Eigen::Vector6d, double> ComputeJTJandJTr(
         std::function<void(int, Eigen::Vector6d &, double &)> f,
-        int iteration_num);
+        int iteration_num, bool verbose);
 
-template std::tuple<Eigen::Matrix6d, Eigen::Vector6d> ComputeJTJandJTr(
+template std::tuple<Eigen::Matrix6d, Eigen::Vector6d, double> ComputeJTJandJTr(
         std::function<void(int, std::vector<Eigen::Vector6d> &,
-        std::vector<double> &)> f, int iteration_num);
+        std::vector<double> &)> f, int iteration_num, bool verbose);
 
 }    // namespace open3d

--- a/src/Core/Utility/Eigen.h
+++ b/src/Core/Utility/Eigen.h
@@ -71,20 +71,20 @@ std::tuple<bool, std::vector<Eigen::Matrix4d>>
 
 /// Function to compute JTJ and Jtr
 /// Input: function pointer f and total number of rows of Jacobian matrix
-/// Output: JTJ and JTr
+/// Output: JTJ, JTr, sum of r^2
 /// Note: f takes index of row, and outputs corresponding residual and row vector.
 template<typename MatType, typename VecType>
-std::tuple<MatType, VecType> ComputeJTJandJTr(
+std::tuple<MatType, VecType, double> ComputeJTJandJTr(
         std::function<void(int, VecType &, double &)> f,
-        int iteration_num);
+        int iteration_num, bool verbose = true);
 
 /// Function to compute JTJ and Jtr
 /// Input: function pointer f and total number of rows of Jacobian matrix
-/// Output: JTJ and JTr
+/// Output: JTJ, JTr, sum of r^2
 /// Note: f takes index of row, and outputs corresponding residual and row vector.
 template<typename MatType, typename VecType>
-std::tuple<MatType, VecType> ComputeJTJandJTr(
+std::tuple<MatType, VecType, double> ComputeJTJandJTr(
         std::function<void(int, std::vector<VecType> &, std::vector<double> &)> f,
-        int iteration_num);
+        int iteration_num, bool verbose = true);
 
 }    // namespace open3d

--- a/src/Python/Core/open3d_colormap.cpp
+++ b/src/Python/Core/open3d_colormap.cpp
@@ -57,7 +57,9 @@ void pybind_colormap_optimization(py::module &m)
          &ColorMapOptimizationOption::depth_threshold_for_discontinuity_check_)
          .def_readwrite("half_dilation_kernel_size_for_discontinuity_map",
          &ColorMapOptimizationOption::half_dilation_kernel_size_for_discontinuity_map_)
-        .def("__repr__", [](const ColorMapOptimizationOption &to) {
+         .def_readwrite("image_boundary_margin",
+         &ColorMapOptimizationOption::image_boundary_margin_)
+         .def("__repr__", [](const ColorMapOptimizationOption &to) {
             return std::string("ColorMapOptimizationOption with") +
                     std::string("\n- non_rigid_camera_coordinate : ") +
                     std::to_string(to.non_rigid_camera_coordinate_) +
@@ -74,7 +76,9 @@ void pybind_colormap_optimization(py::module &m)
                     std::string("\n- depth_threshold_for_discontinuity_check : ") +
                     std::to_string(to.depth_threshold_for_discontinuity_check_) +
                     std::string("\n- half_dilation_kernel_size_for_discontinuity_map : ") +
-                    std::to_string(to.half_dilation_kernel_size_for_discontinuity_map_);
+                    std::to_string(to.half_dilation_kernel_size_for_discontinuity_map_) +
+                    std::string("\n- image_boundary_margin : ") +
+                    std::to_string(to.image_boundary_margin_);
         });
 }
 


### PR DESCRIPTION
This PR reorganizes internal functions in ColorMapOptimization.

Key changes
- A new function for building Jacobian matrices that follows RGBDOdometry structure
- Non-rigid optimization has more than 6 variables (6D camera pose + anchor points). I added a new Eigen helper function that can take n-elements and multiplication pattern. This could be used for general purpose, but non-rigid colormap optimization is the only use case, so I put it inside colormapoptimization.
- Took out ImageWarpingField - it is not general purpose, so I just place it inside colormapoptimization folder.
- Some useful function for mesh colorization using color images are placed inside TriangleMeshAndImageUtilities.cpp. I can polish a tutorial. However, there are many non-general purpose functions as well. We need to discuss for this.
- A new general purpose image processing function is placed in Image.cpp such as CreateDepthBoundaryMask.

I think this PR need some more discussion before it is merged.