### PR TITLE
remove mac flag -Wno-expansion-to-defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,6 @@ elseif (APPLE)
     # enable c++11
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     add_compile_options(-Wno-deprecated-declarations)
-    add_compile_options(-Wno-expansion-to-defined)
     if (NOT BUILD_SHARED_LIBS)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
     endif (NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
Fixes #712 

Previously on CI, there are also a lot of such warnings, see https://travis-ci.org/IntelVCL/Open3D/jobs/460845985#L2675.

This was introduced in a previous commit:
https://github.com/IntelVCL/Open3D/pull/707/files#diff-af3b638bc2a3e6c650974192a53c7291R139

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/722)
<!-- Reviewable:end -->
