### PR TITLE
fix typos: ply_poincloud_reader to ply_pointcloud_reader

### DIFF
--- a/src/IO/FileFormat/FilePLY.cpp
+++ b/src/IO/FileFormat/FilePLY.cpp
@@ -34,7 +34,7 @@ namespace open3d{
 
 namespace {
 
-namespace ply_poincloud_reader {
+namespace ply_pointcloud_reader {
 
 struct PLYReaderState {
     PointCloud *pointcloud_ptr;
@@ -102,7 +102,7 @@ int ReadColorCallback(p_ply_argument argument)
     return 1;
 }
 
-}    // namespace ply_poincloud_reader
+}    // namespace ply_pointcloud_reader
 
 namespace ply_trianglemesh_reader {
 
@@ -205,7 +205,7 @@ int ReadFaceCallBack(p_ply_argument argument)
 
 bool ReadPointCloudFromPLY(const std::string &filename, PointCloud &pointcloud)
 {
-    using namespace ply_poincloud_reader;
+    using namespace ply_pointcloud_reader;
 
     p_ply ply_file = ply_open(filename.c_str(), NULL, 0, NULL);
     if (!ply_file) {


### PR DESCRIPTION
_fix typos in _FilePLY.cpp_: from ply_poincloud_reader to ply_pointcloud_reader_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/729)
<!-- Reviewable:end -->
