### PR TITLE
adjust width of LineSet

### DIFF
--- a/src/Python/Visualization/open3d_renderoption.cpp
+++ b/src/Python/Visualization/open3d_renderoption.cpp
@@ -49,6 +49,7 @@ void pybind_renderoption(py::module &m)
         .def_readwrite("background_color", &RenderOption::background_color_)
         .def_readwrite("light_on", &RenderOption::light_on_)
         .def_readwrite("point_size", &RenderOption::point_size_)
+        .def_readwrite("line_width", &RenderOption::line_width_)
         .def_readwrite("point_show_normal", &RenderOption::point_show_normal_)
         .def_readwrite("show_coordinate_frame", &RenderOption::show_coordinate_frame_);
 }

--- a/src/Visualization/Shader/SimpleShader.cpp
+++ b/src/Visualization/Shader/SimpleShader.cpp
@@ -192,7 +192,7 @@ bool SimpleShaderForLineSet::PrepareRendering(const Geometry &geometry,
         PrintShaderWarning("Rendering type is not LineSet.");
         return false;
     }
-    glLineWidth(1.0f);
+    glLineWidth(GLfloat(option.line_width_));
     glEnable(GL_DEPTH_TEST);
     glDepthFunc(GL_LESS);
     return true;

--- a/src/Visualization/Visualizer/RenderOption.cpp
+++ b/src/Visualization/Visualizer/RenderOption.cpp
@@ -106,6 +106,8 @@ bool RenderOption::ConvertToJsonValue(Json::Value &value) const
         return false;
     }
 
+    value["line_width"] = line_width_;
+
     value["image_stretch_option"] = (int)image_stretch_option_;
     value["image_max_depth"] = image_max_depth_;
 
@@ -213,6 +215,8 @@ bool RenderOption::ConvertFromJsonValue(const Json::Value &value)
             value["default_mesh_color"]) == false ) {
         return false;
     }
+
+    line_width_ = value.get("line_width", line_width_).asDouble();
 
     image_stretch_option_ = (ImageStretchOption)value.get(
             "image_stretch_option", (int)image_stretch_option_).asInt();

--- a/src/Visualization/Visualizer/RenderOption.h
+++ b/src/Visualization/Visualizer/RenderOption.h
@@ -55,6 +55,10 @@ public:
     const double POINT_SIZE_MIN = 1.0;
     const double POINT_SIZE_STEP = 1.0;
     const double POINT_SIZE_DEFAULT = 5.0;
+    const double LINE_WIDTH_MAX = 10.0;
+    const double LINE_WIDTH_MIN = 1.0;
+    const double LINE_WIDTH_STEP = 1.0;
+    const double LINE_WIDTH_DEFAULT = 1.0;
 
     // TriangleMesh options
     enum class MeshShadeOption {
@@ -124,6 +128,10 @@ public:
         point_size_ = std::max(std::min(point_size_ + change * POINT_SIZE_STEP,
                 POINT_SIZE_MAX), POINT_SIZE_MIN);
     }
+    void ChangeLineWidth(double change) {
+        line_width_ = std::max(std::min(line_width_ + change * LINE_WIDTH_STEP,
+                LINE_WIDTH_MAX), LINE_WIDTH_MIN);
+    }    
     void TogglePointShowNormal() {
         point_show_normal_ = !point_show_normal_;
     }
@@ -178,6 +186,9 @@ public:
     bool mesh_show_wireframe_ = false;
     Eigen::Vector3d default_mesh_color_ = Eigen::Vector3d(
             0.7, 0.7, 0.7);
+
+    // LineSet options
+    double line_width_ = LINE_WIDTH_DEFAULT;
 
     // Image options
     ImageStretchOption image_stretch_option_ = ImageStretchOption::OriginalSize;

--- a/src/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Visualization/Visualizer/Visualizer.cpp
@@ -396,6 +396,7 @@ void Visualizer::PrintVisualizerHelp()
     PrintInfo("  -- Render mode control --\n");
     PrintInfo("    L            : Turn on/off lighting.\n");
     PrintInfo("    +/-          : Increase/decrease point size.\n");
+    PrintInfo("    Ctrl + +/-   : Increase/decrease width of LineSet.\n");
     PrintInfo("    N            : Turn on/off point cloud normal rendering.\n");
     PrintInfo("    S            : Toggle between mesh flat shading and smooth shading.\n");
     PrintInfo("    W            : Turn on/off mesh wireframe.\n");

--- a/src/Visualization/Visualizer/VisualizerCallback.cpp
+++ b/src/Visualization/Visualizer/VisualizerCallback.cpp
@@ -158,20 +158,32 @@ void Visualizer::KeyPressCallback(GLFWwindow *window,
                 render_option_ptr_->light_on_ ? "ON" : "OFF");
         break;
     case GLFW_KEY_EQUAL:
-        render_option_ptr_->ChangePointSize(1.0);
-        if (render_option_ptr_->point_show_normal_) {
-            UpdateGeometry();
+        if (mods & GLFW_MOD_SHIFT) {
+            render_option_ptr_->ChangeLineWidth(1.0);
+            PrintDebug("[Visualizer] Line width set to %.2f.\n",
+                       render_option_ptr_->line_width_);
+        } else {
+            render_option_ptr_->ChangePointSize(1.0);
+            if (render_option_ptr_->point_show_normal_) {
+                UpdateGeometry();
+            }
+            PrintDebug("[Visualizer] Point size set to %.2f.\n",
+                       render_option_ptr_->point_size_);
         }
-        PrintDebug("[Visualizer] Point size set to %.2f.\n",
-                render_option_ptr_->point_size_);
         break;
     case GLFW_KEY_MINUS:
-        render_option_ptr_->ChangePointSize(-1.0);
-        if (render_option_ptr_->point_show_normal_) {
-            UpdateGeometry();
+        if (mods & GLFW_MOD_SHIFT) {
+            render_option_ptr_->ChangeLineWidth(-1.0);
+            PrintDebug("[Visualizer] Line width set to %.2f.\n",
+                    render_option_ptr_->line_width_);
+        } else { 
+            render_option_ptr_->ChangePointSize(-1.0);
+            if (render_option_ptr_->point_show_normal_) {
+                UpdateGeometry();
+            }
+            PrintDebug("[Visualizer] Point size set to %.2f.\n",
+                    render_option_ptr_->point_size_);
         }
-        PrintDebug("[Visualizer] Point size set to %.2f.\n",
-                render_option_ptr_->point_size_);
         break;
     case GLFW_KEY_N:
         render_option_ptr_->TogglePointShowNormal();


### PR DESCRIPTION
addresses #734.

- Adding "shift + +/-" key event that can change width of LineSet for the visualization
- Add line_width in RenderOption and corresponding Python binding
- Applies to C++/Python API

Screen shot
<img width="300" alt="screen shot 2018-12-17 at 12 47 16 pm" src="https://user-images.githubusercontent.com/18297113/50114639-de535b00-01f9-11e9-9491-e09067c22262.png"><img width="300" alt="screen shot 2018-12-17 at 12 47 10 pm" src="https://user-images.githubusercontent.com/18297113/50114651-e57a6900-01f9-11e9-86f8-99c40687a575.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/738)
<!-- Reviewable:end -->

