### PR TITLE
IO for LineSet

### DIFF
--- a/src/IO/ClassIO/LineSetIO.cpp
+++ b/src/IO/ClassIO/LineSetIO.cpp
@@ -1,0 +1,106 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "LineSetIO.h"
+
+#include <unordered_map>
+#include <Core/Utility/Console.h>
+#include <Core/Utility/FileSystem.h>
+
+namespace open3d{
+
+namespace {
+
+static const std::unordered_map<std::string,
+        std::function<bool(const std::string &, LineSet &)>>
+        file_extension_to_pointcloud_read_function
+        {{"ply", ReadLineSetFromPLY},
+        };
+
+static const std::unordered_map<std::string,
+        std::function<bool(const std::string &, const LineSet &,
+        const bool, const bool)>>
+        file_extension_to_pointcloud_write_function
+        {{"ply", WriteLineSetToPLY},
+        };
+}    // unnamed namespace
+
+std::shared_ptr<LineSet> CreateLineSetFromFile(
+    const std::string &filename, const std::string &format)
+{
+    auto pointcloud = std::make_shared<LineSet>();
+    ReadLineSet(filename, *pointcloud, format);
+    return pointcloud;
+}
+
+bool ReadLineSet(const std::string &filename, LineSet &pointcloud,
+        const std::string &format)
+{
+    std::string filename_ext;
+    if (format == "auto") {
+        filename_ext = filesystem::GetFileExtensionInLowerCase(filename);
+    } else {
+        filename_ext = format;
+    }
+    if (filename_ext.empty()) {
+        PrintWarning("Read LineSet failed: unknown file extension.\n");
+        return false;
+    }
+    auto map_itr =
+            file_extension_to_pointcloud_read_function.find(filename_ext);
+    if (map_itr == file_extension_to_pointcloud_read_function.end()) {
+        PrintWarning("Read LineSet failed: unknown file extension.\n");
+        return false;
+    }
+    bool success = map_itr->second(filename, pointcloud);
+    PrintDebug("Read LineSet: %d vertices.\n",
+            (int)pointcloud.points_.size());
+    return success;
+}
+
+bool WriteLineSet(const std::string &filename, const LineSet &pointcloud,
+        bool write_ascii/* = false*/, bool compressed/* = false*/)
+{
+    std::string filename_ext =
+            filesystem::GetFileExtensionInLowerCase(filename);
+    if (filename_ext.empty()) {
+        PrintWarning("Write LineSet failed: unknown file extension.\n");
+        return false;
+    }
+    auto map_itr =
+            file_extension_to_pointcloud_write_function.find(filename_ext);
+    if (map_itr == file_extension_to_pointcloud_write_function.end()) {
+        PrintWarning("Write LineSet failed: unknown file extension.\n");
+        return false;
+    }
+    bool success = map_itr->second(filename, pointcloud, write_ascii,
+            compressed);
+    PrintDebug("Write LineSet: %d vertices.\n",
+            (int)pointcloud.points_.size());
+    return success;
+}
+
+}    // namespace open3d

--- a/src/IO/ClassIO/LineSetIO.cpp
+++ b/src/IO/ClassIO/LineSetIO.cpp
@@ -36,14 +36,14 @@ namespace {
 
 static const std::unordered_map<std::string,
         std::function<bool(const std::string &, LineSet &)>>
-        file_extension_to_pointcloud_read_function
+        file_extension_to_lineset_read_function
         {{"ply", ReadLineSetFromPLY},
         };
 
 static const std::unordered_map<std::string,
         std::function<bool(const std::string &, const LineSet &,
         const bool, const bool)>>
-        file_extension_to_pointcloud_write_function
+        file_extension_to_lineset_write_function
         {{"ply", WriteLineSetToPLY},
         };
 }    // unnamed namespace
@@ -51,12 +51,12 @@ static const std::unordered_map<std::string,
 std::shared_ptr<LineSet> CreateLineSetFromFile(
     const std::string &filename, const std::string &format)
 {
-    auto pointcloud = std::make_shared<LineSet>();
-    ReadLineSet(filename, *pointcloud, format);
-    return pointcloud;
+    auto lineset = std::make_shared<LineSet>();
+    ReadLineSet(filename, *lineset, format);
+    return lineset;
 }
 
-bool ReadLineSet(const std::string &filename, LineSet &pointcloud,
+bool ReadLineSet(const std::string &filename, LineSet &lineset,
         const std::string &format)
 {
     std::string filename_ext;
@@ -70,18 +70,18 @@ bool ReadLineSet(const std::string &filename, LineSet &pointcloud,
         return false;
     }
     auto map_itr =
-            file_extension_to_pointcloud_read_function.find(filename_ext);
-    if (map_itr == file_extension_to_pointcloud_read_function.end()) {
+            file_extension_to_lineset_read_function.find(filename_ext);
+    if (map_itr == file_extension_to_lineset_read_function.end()) {
         PrintWarning("Read LineSet failed: unknown file extension.\n");
         return false;
     }
-    bool success = map_itr->second(filename, pointcloud);
+    bool success = map_itr->second(filename, lineset);
     PrintDebug("Read LineSet: %d vertices.\n",
-            (int)pointcloud.points_.size());
+            (int)lineset.points_.size());
     return success;
 }
 
-bool WriteLineSet(const std::string &filename, const LineSet &pointcloud,
+bool WriteLineSet(const std::string &filename, const LineSet &lineset,
         bool write_ascii/* = false*/, bool compressed/* = false*/)
 {
     std::string filename_ext =
@@ -91,15 +91,15 @@ bool WriteLineSet(const std::string &filename, const LineSet &pointcloud,
         return false;
     }
     auto map_itr =
-            file_extension_to_pointcloud_write_function.find(filename_ext);
-    if (map_itr == file_extension_to_pointcloud_write_function.end()) {
+            file_extension_to_lineset_write_function.find(filename_ext);
+    if (map_itr == file_extension_to_lineset_write_function.end()) {
         PrintWarning("Write LineSet failed: unknown file extension.\n");
         return false;
     }
-    bool success = map_itr->second(filename, pointcloud, write_ascii,
+    bool success = map_itr->second(filename, lineset, write_ascii,
             compressed);
     PrintDebug("Write LineSet: %d vertices.\n",
-            (int)pointcloud.points_.size());
+            (int)lineset.points_.size());
     return success;
 }
 

--- a/src/IO/ClassIO/LineSetIO.h
+++ b/src/IO/ClassIO/LineSetIO.h
@@ -26,13 +26,36 @@
 
 #pragma once
 
-#include "ClassIO/PointCloudIO.h"
-#include "ClassIO/TriangleMeshIO.h"
-#include "ClassIO/LineSetIO.h"
-#include "ClassIO/ImageIO.h"
-#include "ClassIO/PinholeCameraTrajectoryIO.h"
-#include "ClassIO/IJsonConvertibleIO.h"
-#include "ClassIO/FeatureIO.h"
-#include "ClassIO/PoseGraphIO.h"
+#include <string>
+#include <Core/Geometry/LineSet.h>
 
-#include "../Open3DConfig.h"
+namespace open3d {
+
+/// Factory function to create a lineset from a file (LineSetFactory.cpp)
+/// Return an empty lineset if fail to read the file.
+std::shared_ptr<LineSet> CreateLineSetFromFile(
+    const std::string &filename, const std::string &format = "auto");
+
+/// The general entrance for reading a LineSet from a file
+/// The function calls read functions based on the extension name of filename.
+/// \return return true if the read function is successful, false otherwise.
+bool ReadLineSet(const std::string &filename, LineSet &lineset,
+        const std::string &format = "auto");
+
+/// The general entrance for writing a LineSet to a file
+/// The function calls write functions based on the extension name of filename.
+/// If the write function supports binary encoding and compression, the later
+/// two parameters will be used. Otherwise they will be ignored.
+/// \return return true if the write function is successful, false otherwise.
+bool WriteLineSet(const std::string &filename, const LineSet &lineset,
+        bool write_ascii = false, bool compressed = false);
+
+bool ReadLineSetFromPLY(
+        const std::string &filename,
+        LineSet &lineset);
+
+bool WriteLineSetToPLY(const std::string &filename,
+        const LineSet &lineset, bool write_ascii = false,
+        bool compressed = false);
+
+}    // namespace open3d

--- a/src/IO/ClassIO/LineSetIO.h
+++ b/src/IO/ClassIO/LineSetIO.h
@@ -31,7 +31,7 @@
 
 namespace open3d {
 
-/// Factory function to create a lineset from a file (LineSetFactory.cpp)
+/// Factory function to create a lineset from a file.
 /// Return an empty lineset if fail to read the file.
 std::shared_ptr<LineSet> CreateLineSetFromFile(
     const std::string &filename, const std::string &format = "auto");

--- a/src/IO/ClassIO/LineSetIO.h
+++ b/src/IO/ClassIO/LineSetIO.h
@@ -32,7 +32,7 @@
 namespace open3d {
 
 /// Factory function to create a lineset from a file.
-/// Return an empty lineset if fail to read the file.
+/// \return return an empty lineset if fail to read the file.
 std::shared_ptr<LineSet> CreateLineSetFromFile(
     const std::string &filename, const std::string &format = "auto");
 

--- a/src/IO/FileFormat/FilePLY.cpp
+++ b/src/IO/FileFormat/FilePLY.cpp
@@ -24,6 +24,7 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include <IO/ClassIO/LineSetIO.h>
 #include <IO/ClassIO/PointCloudIO.h>
 #include <IO/ClassIO/TriangleMeshIO.h>
 
@@ -77,7 +78,7 @@ int ReadNormalCallback(p_ply_argument argument)
 
     double value = ply_get_argument_value(argument);
     state_ptr->pointcloud_ptr->normals_[state_ptr->normal_index](index) = value;
-    if (index == 2) {    // reading 'z'
+    if (index == 2) {    // reading 'nz'
         state_ptr->normal_index++;
     }
     return 1;
@@ -96,7 +97,7 @@ int ReadColorCallback(p_ply_argument argument)
     double value = ply_get_argument_value(argument);
     state_ptr->pointcloud_ptr->colors_[state_ptr->color_index](index) =
             value / 255.0;
-    if (index == 2) {    // reading 'z'
+    if (index == 2) {    // reading 'blue'
         state_ptr->color_index++;
     }
     return 1;
@@ -150,7 +151,7 @@ int ReadNormalCallback(p_ply_argument argument)
     double value = ply_get_argument_value(argument);
     state_ptr->mesh_ptr->vertex_normals_[state_ptr->normal_index](index) =
             value;
-    if (index == 2) {    // reading 'z'
+    if (index == 2) {    // reading 'nz'
         state_ptr->normal_index++;
     }
     return 1;
@@ -169,7 +170,7 @@ int ReadColorCallback(p_ply_argument argument)
     double value = ply_get_argument_value(argument);
     state_ptr->mesh_ptr->vertex_colors_[state_ptr->color_index](index) =
             value / 255.0;
-    if (index == 2) {    // reading 'z'
+    if (index == 2) {    // reading 'blue'
         state_ptr->color_index++;
     }
     return 1;
@@ -198,8 +199,77 @@ int ReadFaceCallBack(p_ply_argument argument)
     return 1;
 }
 
-
 }    // namespace ply_trianglemesh_reader
+
+namespace ply_lineset_reader {
+
+struct PLYReaderState {
+    LineSet *lineset_ptr;
+    long vertex_index;
+    long vertex_num;
+    long line_index;
+    long line_num;
+    long color_index;
+    long color_num;
+};
+
+int ReadVertexCallback(p_ply_argument argument)
+{
+    PLYReaderState *state_ptr;
+    long index;
+    ply_get_argument_user_data(argument,
+            reinterpret_cast<void **>(&state_ptr), &index);
+    if (state_ptr->vertex_index >= state_ptr->vertex_num) {
+        return 0;    // some sanity check
+    }
+
+    double value = ply_get_argument_value(argument);
+    state_ptr->lineset_ptr->points_[state_ptr->vertex_index](index) = value;
+    if (index == 2) {    // reading 'z'
+        state_ptr->vertex_index++;
+        AdvanceConsoleProgress();
+    }
+    return 1;
+}
+
+int ReadLineCallback(p_ply_argument argument)
+{
+    PLYReaderState *state_ptr;
+    long index;
+    ply_get_argument_user_data(argument,
+            reinterpret_cast<void **>(&state_ptr), &index);
+    if (state_ptr->line_index >= state_ptr->line_num) {
+        return 0;
+    }
+
+    double value = ply_get_argument_value(argument);
+    state_ptr->lineset_ptr->lines_[state_ptr->line_index](index) = value;
+    if (index == 1) {    // reading 'vertex2'
+        state_ptr->line_index++;
+    }
+    return 1;
+}
+
+int ReadColorCallback(p_ply_argument argument)
+{
+    PLYReaderState *state_ptr;
+    long index;
+    ply_get_argument_user_data(argument,
+            reinterpret_cast<void **>(&state_ptr), &index);
+    if (state_ptr->color_index >= state_ptr->color_num) {
+        return 0;
+    }
+
+    double value = ply_get_argument_value(argument);
+    state_ptr->lineset_ptr->colors_[state_ptr->color_index](index) =
+        value / 255.0;
+    if (index == 2) {    // reading 'blue'
+        state_ptr->color_index++;
+    }
+    return 1;
+}
+
+}    // namespace ply_lineset_reader
 
 }    // unnamed namespace
 
@@ -467,6 +537,139 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
         ply_write(ply_file, triangle(0));
         ply_write(ply_file, triangle(1));
         ply_write(ply_file, triangle(2));
+        AdvanceConsoleProgress();
+    }
+
+    ply_close(ply_file);
+    return true;
+}
+
+bool ReadLineSetFromPLY(const std::string &filename, LineSet &lineset)
+{
+    using namespace ply_lineset_reader;
+
+    p_ply ply_file = ply_open(filename.c_str(), NULL, 0, NULL);
+    if (!ply_file) {
+        PrintWarning("Read PLY failed: unable to open file: %s\n", filename.c_str());
+        return false;
+    }
+    if (!ply_read_header(ply_file)) {
+        PrintWarning("Read PLY failed: unable to parse header.\n");
+        ply_close(ply_file);
+        return false;
+    }
+
+    PLYReaderState state;
+    state.lineset_ptr = &lineset;
+    state.vertex_num = ply_set_read_cb(ply_file, "vertex", "x",
+            ReadVertexCallback, &state, 0);
+    ply_set_read_cb(ply_file, "vertex", "y",  ReadVertexCallback, &state, 1);
+    ply_set_read_cb(ply_file, "vertex", "z",  ReadVertexCallback, &state, 2);
+
+    state.line_num = ply_set_read_cb(ply_file, "edge", "vertex1",
+            ReadLineCallback, &state, 0);
+    ply_set_read_cb(ply_file, "edge", "vertex2", ReadLineCallback, &state, 1);
+
+    state.color_num = ply_set_read_cb(ply_file, "vertex", "red",
+            ReadColorCallback, &state, 0);
+    ply_set_read_cb(ply_file, "vertex", "green",  ReadColorCallback, &state, 1);
+    ply_set_read_cb(ply_file, "vertex", "blue",  ReadColorCallback, &state, 2);
+
+    if (state.vertex_num <= 0) {
+        PrintWarning("Read PLY failed: number of vertex <= 0.\n");
+        ply_close(ply_file);
+        return false;
+    }
+    if (state.line_num <= 0) {
+        PrintWarning("Read PLY failed: number of edges <= 0.\n");
+        ply_close(ply_file);
+        return false;
+    }
+
+    state.vertex_index = 0;
+    state.line_index = 0;
+    state.color_index = 0;
+
+    lineset.Clear();
+    lineset.points_.resize(state.vertex_num);
+    lineset.lines_.resize(state.line_num);
+    lineset.colors_.resize(state.color_num);
+
+    ResetConsoleProgress(state.vertex_num + 1, "Reading PLY: ");
+
+    if (!ply_read(ply_file)) {
+        PrintWarning("Read PLY failed: unable to read file: %s\n", filename.c_str());
+        ply_close(ply_file);
+        return false;
+    }
+
+    ply_close(ply_file);
+    AdvanceConsoleProgress();
+    return true;
+}
+
+bool WriteLineSetToPLY(const std::string &filename,
+        const LineSet &lineset, bool write_ascii/* = false*/,
+        bool compressed/* = false*/)
+{
+    if (lineset.IsEmpty()) {
+        PrintWarning("Write PLY failed: line set has 0 points.\n");
+        return false;
+    }
+    if (!lineset.HasLines()) {
+        PrintWarning("Write PLY failed: line set has 0 lines.\n");
+        return false;
+    }
+
+    p_ply ply_file = ply_create(filename.c_str(),
+            write_ascii ? PLY_ASCII : PLY_LITTLE_ENDIAN, NULL, 0, NULL);
+    if (!ply_file) {
+        PrintWarning("Write PLY failed: unable to open file: %s\n", filename.c_str());
+        return false;
+    }
+    ply_add_comment(ply_file, "Created by Open3D");
+    ply_add_element(ply_file, "vertex",
+            static_cast<long>(lineset.points_.size()));
+    ply_add_property(ply_file, "x", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "y", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "z", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_element(ply_file, "edge",
+            static_cast<long>(lineset.lines_.size()));
+    ply_add_property(ply_file, "vertex1", PLY_INT, PLY_INT, PLY_INT);
+    ply_add_property(ply_file, "vertex2", PLY_INT, PLY_INT, PLY_INT);
+    if (lineset.HasColors()) {
+        ply_add_property(ply_file, "red", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
+        ply_add_property(ply_file, "green", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
+        ply_add_property(ply_file, "blue", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
+    }
+    if (!ply_write_header(ply_file)) {
+        PrintWarning("Write PLY failed: unable to write header.\n");
+        ply_close(ply_file);
+        return false;
+    }
+
+    ResetConsoleProgress(static_cast<int>(lineset.lines_.size()),
+            "Writing PLY: ");
+
+    for (size_t i = 0; i < lineset.points_.size(); i++) {
+        const Eigen::Vector3d &point = lineset.points_[i];
+        ply_write(ply_file, point(0));
+        ply_write(ply_file, point(1));
+        ply_write(ply_file, point(2));
+    }
+    for (size_t i = 0; i < lineset.lines_.size(); i++) {
+        const Eigen::Vector2i &line = lineset.lines_[i];
+        ply_write(ply_file, line(0));
+        ply_write(ply_file, line(1));
+        if (lineset.HasColors()) {
+            const Eigen::Vector3d &color = lineset.colors_[i];
+            ply_write(ply_file, std::min(255.0, std::max(0.0,
+                    color(0) * 255.0)));
+            ply_write(ply_file, std::min(255.0, std::max(0.0,
+                    color(1) * 255.0)));
+            ply_write(ply_file, std::min(255.0, std::max(0.0,
+                    color(2) * 255.0)));
+        }
         AdvanceConsoleProgress();
     }
 

--- a/src/IO/FileFormat/FilePLY.cpp
+++ b/src/IO/FileFormat/FilePLY.cpp
@@ -570,10 +570,10 @@ bool ReadLineSetFromPLY(const std::string &filename, LineSet &lineset)
             ReadLineCallback, &state, 0);
     ply_set_read_cb(ply_file, "edge", "vertex2", ReadLineCallback, &state, 1);
 
-    state.color_num = ply_set_read_cb(ply_file, "vertex", "red",
+    state.color_num = ply_set_read_cb(ply_file, "edge", "red",
             ReadColorCallback, &state, 0);
-    ply_set_read_cb(ply_file, "vertex", "green",  ReadColorCallback, &state, 1);
-    ply_set_read_cb(ply_file, "vertex", "blue",  ReadColorCallback, &state, 2);
+    ply_set_read_cb(ply_file, "edge", "green",  ReadColorCallback, &state, 1);
+    ply_set_read_cb(ply_file, "edge", "blue",  ReadColorCallback, &state, 2);
 
     if (state.vertex_num <= 0) {
         PrintWarning("Read PLY failed: number of vertex <= 0.\n");

--- a/src/IO/FileFormat/FilePLY.cpp
+++ b/src/IO/FileFormat/FilePLY.cpp
@@ -246,6 +246,7 @@ int ReadLineCallback(p_ply_argument argument)
     state_ptr->lineset_ptr->lines_[state_ptr->line_index](index) = value;
     if (index == 1) {    // reading 'vertex2'
         state_ptr->line_index++;
+        AdvanceConsoleProgress();
     }
     return 1;
 }
@@ -265,6 +266,7 @@ int ReadColorCallback(p_ply_argument argument)
         value / 255.0;
     if (index == 2) {    // reading 'blue'
         state_ptr->color_index++;
+        AdvanceConsoleProgress();
     }
     return 1;
 }
@@ -595,7 +597,8 @@ bool ReadLineSetFromPLY(const std::string &filename, LineSet &lineset)
     lineset.lines_.resize(state.line_num);
     lineset.colors_.resize(state.color_num);
 
-    ResetConsoleProgress(state.vertex_num + 1, "Reading PLY: ");
+    ResetConsoleProgress(state.vertex_num + state.line_num + state.color_num,
+            "Reading PLY: ");
 
     if (!ply_read(ply_file)) {
         PrintWarning("Read PLY failed: unable to read file: %s\n", filename.c_str());
@@ -604,7 +607,6 @@ bool ReadLineSetFromPLY(const std::string &filename, LineSet &lineset)
     }
 
     ply_close(ply_file);
-    AdvanceConsoleProgress();
     return true;
 }
 
@@ -648,7 +650,8 @@ bool WriteLineSetToPLY(const std::string &filename,
         return false;
     }
 
-    ResetConsoleProgress(static_cast<int>(lineset.lines_.size()),
+    ResetConsoleProgress(static_cast<int>(
+            lineset.points_.size() + lineset.lines_.size()),
             "Writing PLY: ");
 
     for (size_t i = 0; i < lineset.points_.size(); i++) {
@@ -656,6 +659,7 @@ bool WriteLineSetToPLY(const std::string &filename,
         ply_write(ply_file, point(0));
         ply_write(ply_file, point(1));
         ply_write(ply_file, point(2));
+        AdvanceConsoleProgress();
     }
     for (size_t i = 0; i < lineset.lines_.size(); i++) {
         const Eigen::Vector2i &line = lineset.lines_[i];

--- a/src/Python/Core/open3d_lineset.cpp
+++ b/src/Python/Core/open3d_lineset.cpp
@@ -28,6 +28,7 @@
 #include "open3d_core_trampoline.h"
 
 #include <Core/Geometry/LineSet.h>
+#include <IO/ClassIO/LineSetIO.h>
 using namespace open3d;
 
 void pybind_lineset(py::module &m)
@@ -55,5 +56,15 @@ void pybind_lineset(py::module &m)
 
 void pybind_lineset_methods(py::module &m)
 {
-    
+    m.def("read_line_set", [](const std::string &filename,
+            const std::string &format) {
+        LineSet line_set;
+        ReadLineSet(filename, line_set, format);
+        return line_set;
+    }, "Function to read LineSet from file", "filename"_a, "format"_a = "auto");
+    m.def("write_line_set", [](const std::string &filename,
+            const LineSet &line_set, bool write_ascii, bool compressed) {
+        return WriteLineSet(filename, line_set, write_ascii, compressed);
+    }, "Function to write LineSet to file", "filename"_a, "line_set"_a,
+            "write_ascii"_a = false, "compressed"_a = false);
 }

--- a/src/Tools/ViewGeometry.cpp
+++ b/src/Tools/ViewGeometry.cpp
@@ -40,6 +40,7 @@ void PrintHelp()
     PrintInfo("    --help, -h                : Print help information.\n");
     PrintInfo("    --mesh file               : Add a triangle mesh from file.\n");
     PrintInfo("    --pointcloud file         : Add a point cloud from file.\n");
+    PrintInfo("    --lineset file            : Add a line set from file.\n");
     PrintInfo("    --image file              : Add an image from file.\n");
     PrintInfo("    --depth file              : Add a point cloud converted from a depth image.\n");
     PrintInfo("    --depth_camera file       : Use with --depth, read a json file that stores\n");
@@ -86,6 +87,8 @@ int main(int argc, char **argv)
     std::string mesh_filename = GetProgramOptionAsString(argc, argv, "--mesh");
     std::string pcd_filename = GetProgramOptionAsString(argc, argv,
             "--pointcloud");
+    std::string lineset_filename = GetProgramOptionAsString(argc, argv,
+            "--lineset");
     std::string image_filename = GetProgramOptionAsString(argc, argv,
             "--image");
     std::string depth_filename = GetProgramOptionAsString(argc, argv,
@@ -122,6 +125,12 @@ int main(int argc, char **argv)
         }
         if (pointcloud_ptr->points_.size() > 5000000) {
             visualizer.GetRenderOption().point_size_ = 1.0;
+        }
+    }
+    if (!lineset_filename.empty()) {
+        auto lineset_ptr = CreateLineSetFromFile(lineset_filename);
+        if (visualizer.AddGeometry(lineset_ptr) == false) {
+            PrintWarning("Failed adding point cloud.\n");
         }
     }
     if (!image_filename.empty()) {

--- a/src/Tools/ViewGeometry.cpp
+++ b/src/Tools/ViewGeometry.cpp
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
     if (!lineset_filename.empty()) {
         auto lineset_ptr = CreateLineSetFromFile(lineset_filename);
         if (visualizer.AddGeometry(lineset_ptr) == false) {
-            PrintWarning("Failed adding point cloud.\n");
+            PrintWarning("Failed adding line set.\n");
         }
     }
     if (!image_filename.empty()) {


### PR DESCRIPTION
Addresses #705.

- Adding I/O functions for LineSet.
- Currently only PLY format is supported for LineSet. (As suggested by @xuyongzhi, PLY format supports ``edge`` to store line fragments.)
- Add "lineset" option into ViewGeometry application

Example:
```
    points = [[0,0,0],[1,0,0],[0,1,0],[1,1,0],
              [0,0,1],[1,0,1],[0,1,1],[1,1,1]]
    lines = [[0,1],[0,2],[1,3],[2,3],
             [4,5],[4,6],[5,7],[6,7],
             [0,4],[1,5],[2,6],[3,7]]
    colors = [[1, 0, 0] for i in range(len(lines))]
    line_set = LineSet()
    line_set.points = Vector3dVector(points)
    line_set.lines = Vector2iVector(lines)
    line_set.colors = Vector3dVector(colors)

    write_line_set("test.ply", line_set, write_ascii=True)
```

This will produce the following file (test.ply).
```
ply
format ascii 1.0
comment Created by Open3D
element vertex 8
property double x
property double y
property double z
element edge 12
property int vertex1
property int vertex2
property uchar red
property uchar green
property uchar blue
end_header
0 0 0
1 0 0
0 1 0
1 1 0
0 0 1
1 0 1
0 1 1
1 1 1
0 1 255 0 0
0 2 255 0 0
1 3 255 0 0
2 3 255 0 0
4 5 255 0 0
4 6 255 0 0
5 7 255 0 0
6 7 255 0 0
0 4 255 0 0
1 5 255 0 0
2 6 255 0 0
3 7 255 0 0
```
This script reads and visualizes LineSet
```
    line_set_read = read_line_set("test.ply")
    draw_geometries([line_set_read])
```
<img width="300" alt="screen shot 2018-12-17 at 2 54 55 pm" src="https://user-images.githubusercontent.com/18297113/50120826-ab19c780-020b-11e9-9c40-4d2aee386c97.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/742)
<!-- Reviewable:end -->
