### PR TITLE
Factorize python module & autogen Python API

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,9 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax']
+extensions = ['sphinx.ext.mathjax',
+        'sphinx.ext.autodoc',
+        'sphinx.ext.autosummary',]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,4 +17,5 @@ Open3D: A Modern Library for 3D Data Processing
   getting_started
   compilation
   tutorial/index
+  python_api/index
   contribute

--- a/docs/python_api/camera.rst
+++ b/docs/python_api/camera.rst
@@ -1,0 +1,10 @@
+Camera
+----------
+.. currentmodule:: open3d.open3d
+
+.. autosummary:: 
+    open3d.open3d.camera
+
+.. automodule:: open3d.open3d.camera
+    :members:
+    

--- a/docs/python_api/geometry.rst
+++ b/docs/python_api/geometry.rst
@@ -1,0 +1,10 @@
+Geometry
+----------
+.. currentmodule:: open3d.open3d
+
+.. autosummary:: 
+    open3d.geometry
+
+.. automodule:: open3d.open3d.geometry
+    :members:
+    

--- a/docs/python_api/index.rst
+++ b/docs/python_api/index.rst
@@ -1,0 +1,11 @@
+Python API
+===================================================================
+
+.. toctree::
+    geometry
+    registration
+    camera
+    odometry
+    visualization
+    integration
+    utility

--- a/docs/python_api/integration.rst
+++ b/docs/python_api/integration.rst
@@ -1,0 +1,10 @@
+Integration
+-----------
+.. currentmodule:: open3d.open3d
+
+.. autosummary:: 
+    open3d.open3d.integration
+
+.. automodule:: open3d.open3d.integration
+    :members:
+    

--- a/docs/python_api/odometry.rst
+++ b/docs/python_api/odometry.rst
@@ -1,0 +1,10 @@
+Odometry
+------------
+.. currentmodule:: open3d.open3d
+
+.. autosummary:: 
+    open3d.open3d.odometry
+
+.. automodule:: open3d.open3d.odometry
+    :members:
+    

--- a/docs/python_api/registration.rst
+++ b/docs/python_api/registration.rst
@@ -1,0 +1,10 @@
+Registration
+------------
+.. currentmodule:: open3d.open3d
+
+.. autosummary:: 
+    open3d.open3d.registration
+
+.. automodule:: open3d.open3d.registration
+    :members:
+    

--- a/docs/python_api/utility.rst
+++ b/docs/python_api/utility.rst
@@ -1,0 +1,10 @@
+Utility
+----------
+.. currentmodule:: open3d.open3d
+
+.. autosummary:: 
+    open3d.open3d.utility
+
+.. automodule:: open3d.open3d.utility
+    :members:
+    

--- a/docs/python_api/visualization.rst
+++ b/docs/python_api/visualization.rst
@@ -1,0 +1,10 @@
+Visualization
+-------------
+.. currentmodule:: open3d.open3d
+
+.. autosummary:: 
+    open3d.open3d.visualization
+
+.. automodule:: open3d.open3d.visualization
+    :members:
+    

--- a/src/Python/Core/open3d_camera.cpp
+++ b/src/Python/Core/open3d_camera.cpp
@@ -36,7 +36,7 @@ using namespace open3d;
 void pybind_camera(py::module &m)
 {
     py::class_<PinholeCameraIntrinsic> pinhole_intr(m,
-            "PinholeCameraIntrinsic");
+            "PinholeCameraIntrinsic", "PinholeCameraIntrinsic");
     py::detail::bind_default_constructor<PinholeCameraIntrinsic>(pinhole_intr);
     py::detail::bind_copy_functions<PinholeCameraIntrinsic>(pinhole_intr);
     pinhole_intr
@@ -64,7 +64,8 @@ void pybind_camera(py::module &m)
                     std::string(".\nAccess intrinsics with intrinsic_matrix.");
         });
     py::enum_<PinholeCameraIntrinsicParameters>(m,
-        "PinholeCameraIntrinsicParameters", py::arithmetic())
+        "PinholeCameraIntrinsicParameters", py::arithmetic(), 
+        "PinholeCameraIntrinsicParameters")
         .value("PrimeSenseDefault",
         PinholeCameraIntrinsicParameters::PrimeSenseDefault)
         .value("Kinect2DepthCameraDefault",
@@ -74,7 +75,7 @@ void pybind_camera(py::module &m)
         .export_values();
 
     py::class_<PinholeCameraParameters> pinhole_param(m,
-            "PinholeCameraParameters");
+            "PinholeCameraParameters", "PinholeCameraParameters");
     py::detail::bind_default_constructor<PinholeCameraParameters>(pinhole_param);
     py::detail::bind_copy_functions<PinholeCameraParameters>(pinhole_param);
     pinhole_param
@@ -86,7 +87,7 @@ void pybind_camera(py::module &m)
         });
 
     py::class_<PinholeCameraTrajectory> pinhole_traj(m,
-            "PinholeCameraTrajectory");
+            "PinholeCameraTrajectory", "PinholeCameraTrajectory");
     py::detail::bind_default_constructor<PinholeCameraTrajectory>(pinhole_traj);
     py::detail::bind_copy_functions<PinholeCameraTrajectory>(pinhole_traj);
     pinhole_traj

--- a/src/Python/Core/open3d_colormap.cpp
+++ b/src/Python/Core/open3d_colormap.cpp
@@ -37,7 +37,7 @@ using namespace open3d;
 void pybind_colormap_optimization(py::module &m)
 {
     py::class_<ColorMapOptimizationOption> color_map_optimization_option(
-             m, "ColorMapOptimizationOption");
+             m, "ColorMapOptimizationOption", "ColorMapOptimizationOption");
     py::detail::bind_default_constructor<ColorMapOptimizationOption>(
             color_map_optimization_option);
     color_map_optimization_option

--- a/src/Python/Core/open3d_console.cpp
+++ b/src/Python/Core/open3d_console.cpp
@@ -31,7 +31,8 @@ using namespace open3d;
 
 void pybind_console(py::module &m)
 {
-    py::enum_<VerbosityLevel>(m, "VerbosityLevel", py::arithmetic())
+    py::enum_<VerbosityLevel>(m, "VerbosityLevel", py::arithmetic(), 
+            "VerbosityLevel")
         .value("Error", VerbosityLevel::VerboseError)
         .value("Warning", VerbosityLevel::VerboseWarning)
         .value("Info", VerbosityLevel::VerboseInfo)

--- a/src/Python/Core/open3d_core.cpp
+++ b/src/Python/Core/open3d_core.cpp
@@ -26,35 +26,48 @@
 
 #include "open3d_core.h"
 
-void pybind_core_classes(py::module &m)
+void pybind_core(py::module &m)
 {
-    pybind_console(m);
-    pybind_geometry(m);
-    pybind_pointcloud(m);
-    pybind_lineset(m);
-    pybind_trianglemesh(m);
-    pybind_image(m);
-    pybind_kdtreeflann(m);
-    pybind_feature(m);
-    pybind_camera(m);
-    pybind_registration(m);
-    pybind_odometry(m);
-    pybind_global_optimization(m);
-    pybind_integration(m);
-    pybind_colormap_optimization(m);
-}
+    py::module m_camera = m.def_submodule("camera");
+    py::module m_geometry = m.def_submodule("geometry");
+    py::module m_odometry = m.def_submodule("odometry");
+    py::module m_registration = m.def_submodule("registration");
+    py::module m_integration = m.def_submodule("integration");
+    py::module m_utility = m.def_submodule("utility");
 
-void pybind_core_methods(py::module &m)
-{
-    pybind_pointcloud_methods(m);
-    pybind_lineset_methods(m);
-    pybind_trianglemesh_methods(m);
-    pybind_image_methods(m);
-    pybind_feature_methods(m);
-    pybind_camera_methods(m);
-    pybind_registration_methods(m);
-    pybind_odometry_methods(m);
-    pybind_global_optimization_methods(m);
-    pybind_integration_methods(m);
-    pybind_colormap_optimization_methods(m);
+    pybind_camera(m_camera);
+
+    pybind_console(m_utility);
+
+    pybind_geometry(m_geometry);
+    pybind_pointcloud(m_geometry);
+    pybind_lineset(m_geometry);
+    pybind_trianglemesh(m_geometry);
+    pybind_image(m_geometry);
+    pybind_kdtreeflann(m_geometry);
+
+    pybind_feature(m_registration);
+    pybind_registration(m_registration);
+    pybind_global_optimization(m_registration);
+    pybind_colormap_optimization(m_registration);
+    
+    pybind_odometry(m_odometry);
+    
+    pybind_integration(m_integration);
+
+    pybind_camera_methods(m_camera);
+    
+    pybind_pointcloud_methods(m_geometry);
+    pybind_lineset_methods(m_geometry);
+    pybind_trianglemesh_methods(m_geometry);
+    pybind_image_methods(m_geometry);
+
+    pybind_feature_methods(m_registration);
+    pybind_registration_methods(m_registration);
+    pybind_global_optimization_methods(m_registration);
+    pybind_colormap_optimization_methods(m_registration);
+
+    pybind_odometry_methods(m_odometry);
+
+    pybind_integration_methods(m_integration);
 }

--- a/src/Python/Core/open3d_feature.cpp
+++ b/src/Python/Core/open3d_feature.cpp
@@ -34,7 +34,8 @@ using namespace open3d;
 
 void pybind_feature(py::module &m)
 {
-    py::class_<Feature, std::shared_ptr<Feature>> feature(m, "Feature");
+    py::class_<Feature, std::shared_ptr<Feature>> feature(m, "Feature", 
+            "Feature");
     py::detail::bind_default_constructor<Feature>(feature);
     py::detail::bind_copy_functions<Feature>(feature);
     feature

--- a/src/Python/Core/open3d_geometry.cpp
+++ b/src/Python/Core/open3d_geometry.cpp
@@ -33,7 +33,7 @@ using namespace open3d;
 void pybind_geometry(py::module &m)
 {
     py::class_<Geometry, PyGeometry<Geometry>, std::shared_ptr<Geometry>>
-            geometry(m, "Geometry");
+            geometry(m, "Geometry", "Geometry");
     geometry
         .def("clear", &Geometry::Clear)
         .def("is_empty", &Geometry::IsEmpty)
@@ -48,14 +48,16 @@ void pybind_geometry(py::module &m)
         .export_values();
 
     py::class_<Geometry3D, PyGeometry3D<Geometry3D>,
-            std::shared_ptr<Geometry3D>, Geometry> geometry3d(m, "Geometry3D");
+            std::shared_ptr<Geometry3D>, Geometry> geometry3d(m, "Geometry3D", 
+            "Geometry3D");
     geometry3d
         .def("get_min_bound", &Geometry3D::GetMinBound)
         .def("get_max_bound", &Geometry3D::GetMaxBound)
         .def("transform", &Geometry3D::Transform);
 
     py::class_<Geometry2D, PyGeometry2D<Geometry2D>,
-            std::shared_ptr<Geometry2D>, Geometry> geometry2d(m, "Geometry2D");
+            std::shared_ptr<Geometry2D>, Geometry> geometry2d(m, "Geometry2D", 
+            "Geometry2D");
     geometry2d
         .def("get_min_bound", &Geometry2D::GetMinBound)
         .def("get_max_bound", &Geometry2D::GetMaxBound);

--- a/src/Python/Core/open3d_global_optimization.cpp
+++ b/src/Python/Core/open3d_global_optimization.cpp
@@ -54,7 +54,7 @@ public:
 void pybind_global_optimization(py::module &m)
 {
     py::class_<PoseGraphNode, std::shared_ptr<PoseGraphNode>>
-            pose_graph_node(m, "PoseGraphNode");
+            pose_graph_node(m, "PoseGraphNode", "PoseGraphNode");
     py::detail::bind_default_constructor<PoseGraphNode>(pose_graph_node);
     py::detail::bind_copy_functions<PoseGraphNode>(pose_graph_node);
     pose_graph_node
@@ -67,7 +67,7 @@ void pybind_global_optimization(py::module &m)
     py::bind_vector<std::vector<PoseGraphNode>>(m, "PoseGraphNodeVector");
 
     py::class_<PoseGraphEdge, std::shared_ptr<PoseGraphEdge>>
-            pose_graph_edge(m, "PoseGraphEdge");
+            pose_graph_edge(m, "PoseGraphEdge", "PoseGraphEdge");
     py::detail::bind_default_constructor<PoseGraphEdge>(pose_graph_edge);
     py::detail::bind_copy_functions<PoseGraphEdge>(pose_graph_edge);
     pose_graph_edge
@@ -111,7 +111,8 @@ void pybind_global_optimization(py::module &m)
 
     py::class_<GlobalOptimizationMethod,
             PyGlobalOptimizationMethod<GlobalOptimizationMethod>>
-            global_optimization_method(m, "GlobalOptimizationMethod");
+            global_optimization_method(m, "GlobalOptimizationMethod", 
+            "GlobalOptimizationMethod");
     global_optimization_method
             .def("OptimizePoseGraph",
             &GlobalOptimizationMethod::OptimizePoseGraph);
@@ -119,6 +120,7 @@ void pybind_global_optimization(py::module &m)
     py::class_<GlobalOptimizationLevenbergMarquardt,
             PyGlobalOptimizationMethod<GlobalOptimizationLevenbergMarquardt>,
             GlobalOptimizationMethod> global_optimization_method_lm(m,
+            "GlobalOptimizationLevenbergMarquardt",
             "GlobalOptimizationLevenbergMarquardt");
     py::detail::bind_default_constructor<GlobalOptimizationLevenbergMarquardt>
             (global_optimization_method_lm);
@@ -132,6 +134,7 @@ void pybind_global_optimization(py::module &m)
     py::class_<GlobalOptimizationGaussNewton,
             PyGlobalOptimizationMethod<GlobalOptimizationGaussNewton>,
             GlobalOptimizationMethod> global_optimization_method_gn(m,
+                "GlobalOptimizationGaussNewton",
                 "GlobalOptimizationGaussNewton");
     py::detail::bind_default_constructor<GlobalOptimizationGaussNewton>
             (global_optimization_method_gn);
@@ -143,7 +146,8 @@ void pybind_global_optimization(py::module &m)
     });
 
     py::class_<GlobalOptimizationConvergenceCriteria> criteria
-            (m, "GlobalOptimizationConvergenceCriteria");
+            (m, "GlobalOptimizationConvergenceCriteria", 
+            "GlobalOptimizationConvergenceCriteria");
     py::detail::bind_default_constructor
             <GlobalOptimizationConvergenceCriteria>(criteria);
     py::detail::bind_copy_functions
@@ -187,7 +191,7 @@ void pybind_global_optimization(py::module &m)
     });
 
     py::class_<GlobalOptimizationOption> option
-            (m, "GlobalOptimizationOption");
+            (m, "GlobalOptimizationOption", "GlobalOptimizationOption");
     py::detail::bind_default_constructor
             <GlobalOptimizationOption>(option);
     py::detail::bind_copy_functions

--- a/src/Python/Core/open3d_image.cpp
+++ b/src/Python/Core/open3d_image.cpp
@@ -35,7 +35,7 @@ using namespace open3d;
 void pybind_image(py::module &m)
 {
     py::class_<Image, PyGeometry2D<Image>, std::shared_ptr<Image>, Geometry2D>
-            image(m, "Image", py::buffer_protocol());
+            image(m, "Image", py::buffer_protocol(), "Image");
     py::detail::bind_default_constructor<Image>(image);
     py::detail::bind_copy_functions<Image>(image);
     image
@@ -114,7 +114,8 @@ void pybind_image(py::module &m)
                     std::string(" channels.\nUse numpy.asarray to access buffer data.");
         });
 
-    py::class_<RGBDImage, std::shared_ptr<RGBDImage>> rgbd_image(m, "RGBDImage");
+    py::class_<RGBDImage, std::shared_ptr<RGBDImage>> rgbd_image(m, "RGBDImage", 
+            "RGBDImage");
     py::detail::bind_default_constructor<RGBDImage>(rgbd_image);
     rgbd_image
         .def_readwrite("color", &RGBDImage::color_)

--- a/src/Python/Core/open3d_integration.cpp
+++ b/src/Python/Core/open3d_integration.cpp
@@ -68,7 +68,7 @@ void pybind_integration(py::module &m)
         .export_values();
 
     py::class_<TSDFVolume, PyTSDFVolume<TSDFVolume>>
-            tsdfvolume(m, "TSDFVolume");
+            tsdfvolume(m, "TSDFVolume", "TSDFVolume");
     tsdfvolume
         .def("reset", &TSDFVolume::Reset, "Function to reset the TSDFVolume")
         .def("integrate", &TSDFVolume::Integrate,
@@ -83,7 +83,7 @@ void pybind_integration(py::module &m)
         .def_readwrite("color_type", &TSDFVolume::color_type_);
 
     py::class_<UniformTSDFVolume, PyTSDFVolume<UniformTSDFVolume>, TSDFVolume>
-            uniform_tsdfvolume(m, "UniformTSDFVolume");
+            uniform_tsdfvolume(m, "UniformTSDFVolume", "UniformTSDFVolume");
     py::detail::bind_copy_functions<UniformTSDFVolume>(
             uniform_tsdfvolume);
     uniform_tsdfvolume
@@ -103,7 +103,7 @@ void pybind_integration(py::module &m)
         .def_readwrite("resolution", &UniformTSDFVolume::resolution_);
 
     py::class_<ScalableTSDFVolume, PyTSDFVolume<ScalableTSDFVolume>, TSDFVolume>
-            scalable_tsdfvolume(m, "ScalableTSDFVolume");
+            scalable_tsdfvolume(m, "ScalableTSDFVolume", "ScalableTSDFVolume");
     py::detail::bind_copy_functions<ScalableTSDFVolume>(
             scalable_tsdfvolume);
     scalable_tsdfvolume

--- a/src/Python/Core/open3d_kdtreeflann.cpp
+++ b/src/Python/Core/open3d_kdtreeflann.cpp
@@ -32,7 +32,8 @@ using namespace open3d;
 
 void pybind_kdtreeflann(py::module &m)
 {
-    py::class_<KDTreeSearchParam> kdtreesearchparam(m, "KDTreeSearchParam");
+    py::class_<KDTreeSearchParam> kdtreesearchparam(m, "KDTreeSearchParam", 
+            "KDTreeSearchParam");
     kdtreesearchparam
         .def("get_search_type", &KDTreeSearchParam::GetSearchType);
     py::enum_<KDTreeSearchParam::SearchType>(kdtreesearchparam, "Type",
@@ -43,7 +44,8 @@ void pybind_kdtreeflann(py::module &m)
         .export_values();
 
     py::class_<KDTreeSearchParamKNN> kdtreesearchparam_knn(m,
-            "KDTreeSearchParamKNN", kdtreesearchparam);
+            "KDTreeSearchParamKNN", kdtreesearchparam, 
+            "KDTreeSearchParamKNN");
     kdtreesearchparam_knn
         .def(py::init<int>(), "knn"_a = 30)
         .def("__repr__", [](const KDTreeSearchParamKNN &param){
@@ -53,7 +55,8 @@ void pybind_kdtreeflann(py::module &m)
         .def_readwrite("knn", &KDTreeSearchParamKNN::knn_);
 
     py::class_<KDTreeSearchParamRadius> kdtreesearchparam_radius(m,
-            "KDTreeSearchParamRadius", kdtreesearchparam);
+            "KDTreeSearchParamRadius", kdtreesearchparam,
+            "KDTreeSearchParamRadius");
     kdtreesearchparam_radius
         .def(py::init<double>(), "radius"_a)
         .def("__repr__", [](const KDTreeSearchParamRadius &param) {
@@ -63,7 +66,8 @@ void pybind_kdtreeflann(py::module &m)
         .def_readwrite("radius", &KDTreeSearchParamRadius::radius_);
 
     py::class_<KDTreeSearchParamHybrid> kdtreesearchparam_hybrid(m,
-            "KDTreeSearchParamHybrid", kdtreesearchparam);
+            "KDTreeSearchParamHybrid", kdtreesearchparam,
+            "KDTreeSearchParamHybrid");
     kdtreesearchparam_hybrid
         .def(py::init<double, int>(), "radius"_a, "max_nn"_a)
         .def("__repr__", [](const KDTreeSearchParamHybrid &param) {
@@ -75,7 +79,7 @@ void pybind_kdtreeflann(py::module &m)
         .def_readwrite("max_nn", &KDTreeSearchParamHybrid::max_nn_);
 
     py::class_<KDTreeFlann, std::shared_ptr<KDTreeFlann>> kdtreeflann(m,
-            "KDTreeFlann");
+            "KDTreeFlann", "KDTreeFlann");
     kdtreeflann.def(py::init<>())
         .def(py::init<const Eigen::MatrixXd &>(), "data"_a)
         .def("set_matrix_data", &KDTreeFlann::SetMatrixData, "data"_a)

--- a/src/Python/Core/open3d_lineset.cpp
+++ b/src/Python/Core/open3d_lineset.cpp
@@ -34,7 +34,7 @@ void pybind_lineset(py::module &m)
 {
     py::class_<LineSet, PyGeometry3D<LineSet>,
             std::shared_ptr<LineSet>, Geometry3D> lineset(m,
-            "LineSet");
+            "LineSet", "LineSet");
     py::detail::bind_default_constructor<LineSet>(lineset);
     py::detail::bind_copy_functions<LineSet>(lineset);
     lineset

--- a/src/Python/Core/open3d_odometry.cpp
+++ b/src/Python/Core/open3d_odometry.cpp
@@ -58,7 +58,7 @@ public:
 
 void pybind_odometry(py::module &m)
 {
-    py::class_<OdometryOption> odometry_option(m, "OdometryOption");
+    py::class_<OdometryOption> odometry_option(m, "OdometryOption", "OdometryOption");
     odometry_option
         .def(py::init([](std::vector<int> iteration_number_per_pyramid_level,
                 double max_depth_diff, double min_depth, double max_depth) {
@@ -94,7 +94,7 @@ void pybind_odometry(py::module &m)
 
     py::class_<RGBDOdometryJacobian,
             PyRGBDOdometryJacobian<RGBDOdometryJacobian>>
-            jacobian(m, "RGBDOdometryJacobian");
+            jacobian(m, "RGBDOdometryJacobian", "RGBDOdometryJacobian");
     jacobian
             .def("compute_jacobian_and_residual",
                     &RGBDOdometryJacobian::ComputeJacobianAndResidual);
@@ -102,6 +102,7 @@ void pybind_odometry(py::module &m)
     py::class_<RGBDOdometryJacobianFromColorTerm,
             PyRGBDOdometryJacobian<RGBDOdometryJacobianFromColorTerm>,
             RGBDOdometryJacobian> jacobian_color(m,
+            "RGBDOdometryJacobianFromColorTerm",
             "RGBDOdometryJacobianFromColorTerm");
     py::detail::bind_default_constructor<RGBDOdometryJacobianFromColorTerm>
             (jacobian_color);
@@ -115,6 +116,7 @@ void pybind_odometry(py::module &m)
     py::class_<RGBDOdometryJacobianFromHybridTerm,
             PyRGBDOdometryJacobian<RGBDOdometryJacobianFromHybridTerm>,
             RGBDOdometryJacobian> jacobian_hybrid(m,
+            "RGBDOdometryJacobianFromHybridTerm",
             "RGBDOdometryJacobianFromHybridTerm");
     py::detail::bind_default_constructor<RGBDOdometryJacobianFromHybridTerm>
         (jacobian_hybrid);

--- a/src/Python/Core/open3d_pointcloud.cpp
+++ b/src/Python/Core/open3d_pointcloud.cpp
@@ -38,7 +38,7 @@ void pybind_pointcloud(py::module &m)
 {
     py::class_<PointCloud, PyGeometry3D<PointCloud>,
             std::shared_ptr<PointCloud>, Geometry3D> pointcloud(m,
-            "PointCloud");
+            "PointCloud", "PointCloud");
     py::detail::bind_default_constructor<PointCloud>(pointcloud);
     py::detail::bind_copy_functions<PointCloud>(pointcloud);
     pointcloud

--- a/src/Python/Core/open3d_registration.cpp
+++ b/src/Python/Core/open3d_registration.cpp
@@ -75,8 +75,8 @@ public:
 
 void pybind_registration(py::module &m)
 {
-    py::class_<ICPConvergenceCriteria> convergence_criteria(m,
-            "ICPConvergenceCriteria");
+    py::class_<ICPConvergenceCriteria> convergence_criteria(
+        m, "ICPConvergenceCriteria", "ICPConvergenceCriteria");
     py::detail::bind_copy_functions<ICPConvergenceCriteria>(
             convergence_criteria);
     convergence_criteria
@@ -99,7 +99,7 @@ void pybind_registration(py::module &m)
         });
 
     py::class_<RANSACConvergenceCriteria> ransac_criteria(m,
-            "RANSACConvergenceCriteria");
+            "RANSACConvergenceCriteria", "RANSACConvergenceCriteria");
     py::detail::bind_copy_functions<RANSACConvergenceCriteria>(
             ransac_criteria);
     ransac_criteria
@@ -120,7 +120,7 @@ void pybind_registration(py::module &m)
 
     py::class_<TransformationEstimation,
             PyTransformationEstimation<TransformationEstimation>>
-            te(m, "TransformationEstimation");
+            te(m, "TransformationEstimation", "TransformationEstimation");
     te
         .def("compute_rmse", &TransformationEstimation::ComputeRMSE)
         .def("compute_transformation",
@@ -129,6 +129,7 @@ void pybind_registration(py::module &m)
     py::class_<TransformationEstimationPointToPoint,
             PyTransformationEstimation<TransformationEstimationPointToPoint>,
             TransformationEstimation> te_p2p(m,
+            "TransformationEstimationPointToPoint",
             "TransformationEstimationPointToPoint");
     py::detail::bind_copy_functions<TransformationEstimationPointToPoint>(
             te_p2p);
@@ -147,6 +148,7 @@ void pybind_registration(py::module &m)
     py::class_<TransformationEstimationPointToPlane,
             PyTransformationEstimation<TransformationEstimationPointToPlane>,
             TransformationEstimation> te_p2l(m,
+            "TransformationEstimationPointToPlane",
             "TransformationEstimationPointToPlane");
     py::detail::bind_default_constructor<TransformationEstimationPointToPlane>(
             te_p2l);
@@ -159,13 +161,14 @@ void pybind_registration(py::module &m)
 
     py::class_<CorrespondenceChecker,
             PyCorrespondenceChecker<CorrespondenceChecker>>
-            cc(m, "CorrespondenceChecker");
+            cc(m, "CorrespondenceChecker", "CorrespondenceChecker");
     cc
             .def("Check", &CorrespondenceChecker::Check);
 
     py::class_<CorrespondenceCheckerBasedOnEdgeLength,
             PyCorrespondenceChecker<CorrespondenceCheckerBasedOnEdgeLength>,
             CorrespondenceChecker> cc_el(m,
+            "CorrespondenceCheckerBasedOnEdgeLength", 
             "CorrespondenceCheckerBasedOnEdgeLength");
     py::detail::bind_copy_functions<CorrespondenceCheckerBasedOnEdgeLength>(
             cc_el);
@@ -184,6 +187,7 @@ void pybind_registration(py::module &m)
     py::class_<CorrespondenceCheckerBasedOnDistance,
             PyCorrespondenceChecker<CorrespondenceCheckerBasedOnDistance>,
             CorrespondenceChecker> cc_d(m,
+            "CorrespondenceCheckerBasedOnDistance",
             "CorrespondenceCheckerBasedOnDistance");
     py::detail::bind_copy_functions<CorrespondenceCheckerBasedOnDistance>(
             cc_d);
@@ -202,6 +206,7 @@ void pybind_registration(py::module &m)
     py::class_<CorrespondenceCheckerBasedOnNormal,
             PyCorrespondenceChecker<CorrespondenceCheckerBasedOnNormal>,
             CorrespondenceChecker> cc_n(m,
+            "CorrespondenceCheckerBasedOnNormal",
             "CorrespondenceCheckerBasedOnNormal");
     py::detail::bind_copy_functions<CorrespondenceCheckerBasedOnNormal>(
             cc_n);
@@ -218,6 +223,7 @@ void pybind_registration(py::module &m)
                 &CorrespondenceCheckerBasedOnNormal::normal_angle_threshold_);
 
     py::class_<FastGlobalRegistrationOption> fgr_option(m,
+            "FastGlobalRegistrationOption",
             "FastGlobalRegistrationOption");
     py::detail::bind_copy_functions<FastGlobalRegistrationOption>(
             fgr_option);
@@ -267,7 +273,8 @@ void pybind_registration(py::module &m)
                     std::to_string(c.maximum_tuple_count_);
         });
 
-    py::class_<RegistrationResult> registration_result(m, "RegistrationResult");
+    py::class_<RegistrationResult> registration_result(m, "RegistrationResult", 
+            "RegistrationResult");
     py::detail::bind_default_constructor<RegistrationResult>(
             registration_result);
     py::detail::bind_copy_functions<RegistrationResult>(registration_result);

--- a/src/Python/Core/open3d_trianglemesh.cpp
+++ b/src/Python/Core/open3d_trianglemesh.cpp
@@ -35,7 +35,7 @@ void pybind_trianglemesh(py::module &m)
 {
     py::class_<TriangleMesh, PyGeometry3D<TriangleMesh>,
             std::shared_ptr<TriangleMesh>, Geometry3D> trianglemesh(m,
-            "TriangleMesh");
+            "TriangleMesh", "TriangleMesh");
     py::detail::bind_default_constructor<TriangleMesh>(trianglemesh);
     py::detail::bind_copy_functions<TriangleMesh>(trianglemesh);
     trianglemesh

--- a/src/Python/IO/open3d_io.cpp
+++ b/src/Python/IO/open3d_io.cpp
@@ -26,10 +26,6 @@
 
 #include "open3d_io.h"
 
-void pybind_io_classes(py::module &m)
-{
-}
-
-void pybind_io_methods(py::module &m)
+void pybind_io(py::module &m)
 {
 }

--- a/src/Python/Package/open3d/__init__.py
+++ b/src/Python/Package/open3d/__init__.py
@@ -27,7 +27,13 @@
 import importlib
 from .open3d import * # py2 py3 compatible
 
-globals().update(importlib.import_module('open3d.open3d').__dict__)
+globals().update(importlib.import_module('open3d.open3d.camera').__dict__)
+globals().update(importlib.import_module('open3d.open3d.geometry').__dict__)
+globals().update(importlib.import_module('open3d.open3d.odometry').__dict__)
+globals().update(importlib.import_module('open3d.open3d.registration').__dict__)
+globals().update(importlib.import_module('open3d.open3d.integration').__dict__)
+globals().update(importlib.import_module('open3d.open3d.utility').__dict__)
+globals().update(importlib.import_module('open3d.open3d.visualization').__dict__)
 
 __version__ = '@PROJECT_VERSION@'
 

--- a/src/Python/Visualization/open3d_visualization.cpp
+++ b/src/Python/Visualization/open3d_visualization.cpp
@@ -26,18 +26,15 @@
 
 #include "open3d_visualization.h"
 
-void pybind_visualization_classes(py::module &m)
+void pybind_visualization(py::module &m)
 {
-    pybind_renderoption(m);
-    pybind_viewcontrol(m);
-    pybind_visualizer(m);
-    pybind_utility(m);
-}
-
-void pybind_visualization_methods(py::module &m)
-{
-    pybind_renderoption_method(m);
-    pybind_viewcontrol_method(m);
-    pybind_visualizer_method(m);
-    pybind_utility_methods(m);
+    py::module m_visualization = m.def_submodule("visualization");
+    pybind_renderoption(m_visualization);
+    pybind_viewcontrol(m_visualization);
+    pybind_visualizer(m_visualization);
+    pybind_utility(m_visualization);
+    pybind_renderoption_method(m_visualization);
+    pybind_viewcontrol_method(m_visualization);
+    pybind_visualizer_method(m_visualization);
+    pybind_utility_methods(m_visualization);
 }

--- a/src/Python/Visualization/open3d_visualizer.cpp
+++ b/src/Python/Visualization/open3d_visualizer.cpp
@@ -37,7 +37,7 @@ using namespace open3d;
 void pybind_visualizer(py::module &m)
 {
     py::class_<Visualizer, PyVisualizer<>, std::shared_ptr<Visualizer>>
-            visualizer(m, "Visualizer");
+            visualizer(m, "Visualizer", "Visualizer");
     py::detail::bind_default_constructor<Visualizer>(visualizer);
     visualizer
         .def("__repr__", [](const Visualizer &vis) {
@@ -86,7 +86,8 @@ void pybind_visualizer(py::module &m)
     py::class_<VisualizerWithKeyCallback,
             PyVisualizer<VisualizerWithKeyCallback>,
             std::shared_ptr<VisualizerWithKeyCallback>>
-            visualizer_key(m, "VisualizerWithKeyCallback", visualizer);
+            visualizer_key(m, "VisualizerWithKeyCallback", visualizer, 
+            "VisualizerWithKeyCallback");
     py::detail::bind_default_constructor<VisualizerWithKeyCallback>(
             visualizer_key);
     visualizer_key
@@ -102,7 +103,8 @@ void pybind_visualizer(py::module &m)
     py::class_<VisualizerWithEditing,
             PyVisualizer<VisualizerWithEditing>,
             std::shared_ptr<VisualizerWithEditing>>
-            visualizer_edit(m, "VisualizerWithEditing", visualizer);
+            visualizer_edit(m, "VisualizerWithEditing", visualizer, 
+            "VisualizerWithEditing");
     py::detail::bind_default_constructor<VisualizerWithEditing>(
             visualizer_edit);
     visualizer_edit

--- a/src/Python/open3d.cpp
+++ b/src/Python/open3d.cpp
@@ -31,11 +31,12 @@ PYBIND11_MODULE(open3d, m) {
 
     pybind_eigen(m);
 
-    pybind_core_classes(m);
+    pybind_core(m);
+    // pybind_core_classes(m);
     pybind_io_classes(m);
-    pybind_visualization_classes(m);
+    pybind_visualization(m);
 
-    pybind_core_methods(m);
+    // pybind_core_methods(m);
     pybind_io_methods(m);
-    pybind_visualization_methods(m);
+    // pybind_visualization_methods(m);
 }

--- a/src/Python/open3d.cpp
+++ b/src/Python/open3d.cpp
@@ -32,11 +32,6 @@ PYBIND11_MODULE(open3d, m) {
     pybind_eigen(m);
 
     pybind_core(m);
-    // pybind_core_classes(m);
-    pybind_io_classes(m);
+    pybind_io(m);
     pybind_visualization(m);
-
-    // pybind_core_methods(m);
-    pybind_io_methods(m);
-    // pybind_visualization_methods(m);
 }

--- a/src/Python/open3d.h
+++ b/src/Python/open3d.h
@@ -77,10 +77,11 @@ void bind_copy_functions(Class_ &cl) {
 
 void pybind_eigen(py::module &m);
 
-void pybind_core_classes(py::module &m);
+void pybind_core(py::module &m);
+// void pybind_core_classes(py::module &m);
 void pybind_io_classes(py::module &m);
-void pybind_visualization_classes(py::module &m);
+void pybind_visualization(py::module &m);
 
-void pybind_core_methods(py::module &m);
+// void pybind_core_methods(py::module &m);
 void pybind_io_methods(py::module &m);
-void pybind_visualization_methods(py::module &m);
+// void pybind_visualization_methods(py::module &m);

--- a/src/Python/open3d.h
+++ b/src/Python/open3d.h
@@ -78,10 +78,5 @@ void bind_copy_functions(Class_ &cl) {
 void pybind_eigen(py::module &m);
 
 void pybind_core(py::module &m);
-// void pybind_core_classes(py::module &m);
-void pybind_io_classes(py::module &m);
+void pybind_io(py::module &m);
 void pybind_visualization(py::module &m);
-
-// void pybind_core_methods(py::module &m);
-void pybind_io_methods(py::module &m);
-// void pybind_visualization_methods(py::module &m);


### PR DESCRIPTION
Resolves #747 and #748

**Key changes**
- make submodules (geometry, registration, camera, odometry, visualization, integration, utility) for open3d python package.
- make a basic structure in the doc folder to automatically generate Python API.
- add some doc elements for binded classes so that ``sphinx-autodoc`` can make a documents.

**Need to do**
- need to configure open3d.org/docs
- add more descriptions for the functions and classes
- it would be great if we can link tutorial examples with this API document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/749)
<!-- Reviewable:end -->
