### PR TITLE
alternate way of detecting conda active environment

### DIFF
--- a/src/Python/check_and_install_conda_deps.cmake
+++ b/src/Python/check_and_install_conda_deps.cmake
@@ -1,10 +1,13 @@
 # Assert that we're inside a conda environemnt
-message(STATUS "Asserting this is Conda python: ${PYTHON_EXECUTABLE} ...")
+message(STATUS "Checking Conda environment...")
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; assert 'conda' in sys.version"
+    COMMAND bash "-c" "conda info | grep -q \"active environment : None\""
     RESULT_VARIABLE return_code
 )
+
 if (${return_code})
+    message("Conda environment is active.")
+else()
     message(FATAL_ERROR "Not in a conda environment: 1) activate conda, 2) rerun cmake and make")
 endif()
 


### PR DESCRIPTION
The original code failed on a miniconda3 installation - sys.version did not include the 'conda' substring.

For miniconda2, sys.version reports:
'2.7.15 |Anaconda, Inc.| (default, Dec 14 2018, 19:04:19) \n[GCC 7.3.0]'

For miniconda3, sys.version reports:
'3.7.1 (default, Dec 14 2018, 19:28:38) \n[GCC 7.3.0]'

Using 'conda info' we can tell whether a conda environment is active or not:

(base) root@open3d-test-14# conda info | grep "active environment"
     active environment : base
(base) root@open3d-test-14# conda deactivate
root@open3d-test-14# conda info | grep "active environment"
     active environment : None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/750)
<!-- Reviewable:end -->
