### PR TITLE
Remove unneeded std::move calls

### DIFF
--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -46,8 +46,8 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
             Eigen::MatrixXd x = A.ldlt().solve(b);
             return std::make_tuple(solution_exist, std::move(x));
         } else {
-            return std::make_tuple(false,
-                    std::move(Eigen::VectorXd::Zero(b.rows())));
+            return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
+                    
         }
     } else {
         Eigen::MatrixXd x = A.ldlt().solve(b);
@@ -101,7 +101,7 @@ std::tuple<bool, Eigen::Matrix4d>
         return std::make_tuple(solution_exist, std::move(extrinsic));
     }
     else {
-        return std::make_tuple(false, std::move(Eigen::Matrix4d::Identity()));
+        return std::make_tuple(false, Eigen::Matrix4d::Identity());
     }
 }
 


### PR DESCRIPTION
Fixes -Wpessimizing-move warnings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/755)
<!-- Reviewable:end -->
