### PR TITLE
only keep xcode10.1 for mac travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,19 +87,6 @@ matrix:
       before_install: ./util/scripts/setup-linux.sh
       script: ./util/scripts/run-travis.sh
 
-    # Default environment of macOS 10.12 Sierra
-    # compiled using clang shipped with xcode8.3
-    - os: osx
-      osx_image: xcode8.3
-      script: travis_wait 30 ./util/scripts/run-travis.sh
-      before_install: ./util/scripts/setup-osx.sh
-
-    - os: osx
-      osx_image: xcode8.3
-      env: SHARED=ON
-      before_install: ./util/scripts/setup-osx.sh
-      script: travis_wait 30 ./util/scripts/run-travis.sh
-
     # Default environment of macOS 10.13 High Sierra
     # compiled using clang shipped with xcode10.1
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,20 +87,20 @@ matrix:
       before_install: ./util/scripts/setup-linux.sh
       script: ./util/scripts/run-travis.sh
 
-    # Default environment of MacOS El Capitan
-    # compiled using clang shipped with xcode8
+    # Default environment of macOS 10.12 Sierra
+    # compiled using clang shipped with xcode8.3
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       script: travis_wait 30 ./util/scripts/run-travis.sh
       before_install: ./util/scripts/setup-osx.sh
 
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env: SHARED=ON
       before_install: ./util/scripts/setup-osx.sh
       script: travis_wait 30 ./util/scripts/run-travis.sh
 
-    # Default environment of MacOS 10.13
+    # Default environment of macOS 10.13 High Sierra
     # compiled using clang shipped with xcode10.1
     - os: osx
       osx_image: xcode10.1


### PR DESCRIPTION
If switching to xcode 8.3 doesn't help the mac build time, we can consider only keeping the latest version of xcode available on Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/792)
<!-- Reviewable:end -->
