### PR TITLE
clang-format: remove indentation for class access modifiers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,5 +6,5 @@ Language: Cpp
 Standard: Cpp11
 SortIncludes: false
 ContinuationIndentWidth: 8
-AccessModifierOffset: -2
+AccessModifierOffset: -4
 BinPackParameters: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,20 +111,7 @@ matrix:
       before_install: ./util/scripts/setup-linux.sh
       script: ./util/scripts/run-travis.sh
 
-    # Default environment of MacOS El Capitan
-    # compiled using clang shipped with xcode8
-    - os: osx
-      osx_image: xcode8
-      script: travis_wait 30 ./util/scripts/run-travis.sh
-      before_install: ./util/scripts/setup-osx.sh
-
-    - os: osx
-      osx_image: xcode8
-      env: SHARED=ON
-      before_install: ./util/scripts/setup-osx.sh
-      script: travis_wait 30 ./util/scripts/run-travis.sh
-
-    # Default environment of MacOS 10.13
+    # Default environment of macOS 10.13 High Sierra
     # compiled using clang shipped with xcode10.1
     - os: osx
       osx_image: xcode10.1

--- a/examples/Cpp/DepthCapture.cpp
+++ b/examples/Cpp/DepthCapture.cpp
@@ -35,7 +35,7 @@
 using namespace open3d;
 
 class VisualizerWithDepthCapture : public VisualizerWithCustomAnimation {
-  protected:
+protected:
     void KeyPressCallback(GLFWwindow *window,
                           int key,
                           int scancode,

--- a/examples/Cpp/EvaluateFeatureMatch.cpp
+++ b/examples/Cpp/EvaluateFeatureMatch.cpp
@@ -34,11 +34,11 @@
 #include <Visualization/Visualization.h>
 
 class KDTreeFlannFeature {
-  public:
+public:
     KDTreeFlannFeature() {}
     ~KDTreeFlannFeature() {}
 
-  public:
+public:
     bool LoadFromFile(const std::string &filename) {
         FILE *fid = fopen(filename.c_str(), "rb");
         fread(&dataset_size_, sizeof(int), 1, fid);
@@ -75,7 +75,7 @@ class KDTreeFlannFeature {
                                        knn, flann::SearchParams(-1, 0.0));
     }
 
-  public:
+public:
     std::vector<float> data_;
     std::unique_ptr<flann::Matrix<float>> flann_dataset_;
     std::unique_ptr<flann::Index<flann::L2<float>>> flann_index_;

--- a/src/Core/Camera/PinholeCameraIntrinsic.h
+++ b/src/Core/Camera/PinholeCameraIntrinsic.h
@@ -38,14 +38,14 @@ enum class PinholeCameraIntrinsicParameters {
 };
 
 class PinholeCameraIntrinsic : public IJsonConvertible {
-  public:
+public:
     PinholeCameraIntrinsic();
     PinholeCameraIntrinsic(PinholeCameraIntrinsicParameters);
     PinholeCameraIntrinsic(
             int width, int height, double fx, double fy, double cx, double cy);
     ~PinholeCameraIntrinsic() override;
 
-  public:
+public:
     void SetIntrinsics(
             int width, int height, double fx, double fy, double cx, double cy) {
         width_ = width;
@@ -72,7 +72,7 @@ class PinholeCameraIntrinsic : public IJsonConvertible {
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     int width_ = -1;
     int height_ = -1;
     Eigen::Matrix3d intrinsic_matrix_;

--- a/src/Core/Camera/PinholeCameraParameters.h
+++ b/src/Core/Camera/PinholeCameraParameters.h
@@ -34,15 +34,15 @@
 namespace open3d {
 
 class PinholeCameraParameters : public IJsonConvertible {
-  public:
+public:
     PinholeCameraParameters();
     ~PinholeCameraParameters() override;
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     PinholeCameraIntrinsic intrinsic_;
     Eigen::Matrix4d_u extrinsic_;
 };

--- a/src/Core/Camera/PinholeCameraTrajectory.h
+++ b/src/Core/Camera/PinholeCameraTrajectory.h
@@ -34,15 +34,15 @@
 namespace open3d {
 
 class PinholeCameraTrajectory : public IJsonConvertible {
-  public:
+public:
     PinholeCameraTrajectory();
     ~PinholeCameraTrajectory() override;
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     std::vector<PinholeCameraParameters> parameters_;
 };
 

--- a/src/Core/ColorMap/ColorMapOptimization.h
+++ b/src/Core/ColorMap/ColorMapOptimization.h
@@ -37,7 +37,7 @@ class Image;
 class PinholeCameraTrajectory;
 
 class ColorMapOptimizationOption {
-  public:
+public:
     ColorMapOptimizationOption(
             bool non_rigid_camera_coordinate = false,
             int number_of_vertical_anchors = 16,
@@ -62,7 +62,7 @@ class ColorMapOptimizationOption {
           image_boundary_margin_(image_boundary_margin) {}
     ~ColorMapOptimizationOption() {}
 
-  public:
+public:
     bool non_rigid_camera_coordinate_;
     int number_of_vertical_anchors_;
     double non_rigid_anchor_point_weight_;

--- a/src/Core/ColorMap/ColorMapOptimizationJacobian.h
+++ b/src/Core/ColorMap/ColorMapOptimizationJacobian.h
@@ -40,10 +40,10 @@ class ImageWarpingField;
 class TriangleMesh;
 
 class ColorMapOptimizationJacobian {
-  public:
+public:
     ColorMapOptimizationJacobian() {}
 
-  public:
+public:
     /// Function to compute i-th row of J and r
     /// the vector form of J_r is basically 6x1 matrix, but it can be
     /// easily extendable to 6xn matrix.

--- a/src/Core/ColorMap/ImageWarpingField.h
+++ b/src/Core/ColorMap/ImageWarpingField.h
@@ -31,7 +31,7 @@
 namespace open3d {
 
 class ImageWarpingField : public IJsonConvertible {
-  public:
+public:
     ImageWarpingField();
     ImageWarpingField(int width, int height, int number_of_vertical_anchors);
     void InitializeWarpingFields(int width,
@@ -40,11 +40,11 @@ class ImageWarpingField : public IJsonConvertible {
     Eigen::Vector2d QueryFlow(int i, int j) const;
     Eigen::Vector2d GetImageWarpingField(double u, double v) const;
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     Eigen::VectorXd flow_;
     int anchor_w_;
     int anchor_h_;

--- a/src/Core/Geometry/DownSample.cpp
+++ b/src/Core/Geometry/DownSample.cpp
@@ -39,14 +39,14 @@ namespace open3d {
 namespace {
 
 class AccumulatedPoint {
-  public:
+public:
     AccumulatedPoint()
         : num_of_points_(0),
           point_(0.0, 0.0, 0.0),
           normal_(0.0, 0.0, 0.0),
           color_(0.0, 0.0, 0.0) {}
 
-  public:
+public:
     void AddPoint(const PointCloud &cloud, int index) {
         point_ += cloud.points_[index];
         if (cloud.HasNormals()) {
@@ -72,7 +72,7 @@ class AccumulatedPoint {
         return color_ / double(num_of_points_);
     }
 
-  public:
+public:
     int num_of_points_;
     Eigen::Vector3d point_;
     Eigen::Vector3d normal_;
@@ -80,13 +80,13 @@ class AccumulatedPoint {
 };
 
 class point_cubic_id {
-  public:
+public:
     size_t point_id;
     int cubic_id;
 };
 
 class AccumulatedPointForTrace : public AccumulatedPoint {
-  public:
+public:
     void AddPoint(const PointCloud &cloud,
                   size_t index,
                   int cubic_index,
@@ -131,7 +131,7 @@ class AccumulatedPointForTrace : public AccumulatedPoint {
 
     std::vector<point_cubic_id> GetOriginalID() { return original_id; }
 
-  private:
+private:
     // original point cloud id in higher resolution + its cubic id
     std::vector<point_cubic_id> original_id;
     std::unordered_map<int, int> classes;

--- a/src/Core/Geometry/Geometry.h
+++ b/src/Core/Geometry/Geometry.h
@@ -29,7 +29,7 @@
 namespace open3d {
 
 class Geometry {
-  public:
+public:
     enum class GeometryType {
         Unspecified = 0,
         PointCloud = 1,
@@ -40,20 +40,20 @@ class Geometry {
         Image = 6,
     };
 
-  public:
+public:
     virtual ~Geometry() {}
 
-  protected:
+protected:
     Geometry(GeometryType type, int dimension)
         : geometry_type_(type), dimension_(dimension) {}
 
-  public:
+public:
     virtual void Clear() = 0;
     virtual bool IsEmpty() const = 0;
     GeometryType GetGeometryType() const { return geometry_type_; }
     int Dimension() const { return dimension_; }
 
-  private:
+private:
     GeometryType geometry_type_ = GeometryType::Unspecified;
     int dimension_ = 3;
 };

--- a/src/Core/Geometry/Geometry2D.h
+++ b/src/Core/Geometry/Geometry2D.h
@@ -32,13 +32,13 @@
 namespace open3d {
 
 class Geometry2D : public Geometry {
-  public:
+public:
     ~Geometry2D() override {}
 
-  protected:
+protected:
     Geometry2D(GeometryType type) : Geometry(type, 2) {}
 
-  public:
+public:
     void Clear() override = 0;
     bool IsEmpty() const override = 0;
     virtual Eigen::Vector2d GetMinBound() const = 0;

--- a/src/Core/Geometry/Geometry3D.h
+++ b/src/Core/Geometry/Geometry3D.h
@@ -32,13 +32,13 @@
 namespace open3d {
 
 class Geometry3D : public Geometry {
-  public:
+public:
     ~Geometry3D() override {}
 
-  protected:
+protected:
     Geometry3D(GeometryType type) : Geometry(type, 3) {}
 
-  public:
+public:
     void Clear() override = 0;
     bool IsEmpty() const override = 0;
     virtual Eigen::Vector3d GetMinBound() const = 0;

--- a/src/Core/Geometry/Image.h
+++ b/src/Core/Geometry/Image.h
@@ -38,7 +38,7 @@ namespace open3d {
 class PinholeCameraIntrinsic;
 
 class Image : public Geometry2D {
-  public:
+public:
     enum class ColorToIntensityConversionType {
         Equal,
         Weighted,
@@ -52,18 +52,18 @@ class Image : public Geometry2D {
         Sobel3Dy
     };
 
-  public:
+public:
     Image() : Geometry2D(Geometry::GeometryType::Image){};
     ~Image() override{};
 
-  public:
+public:
     void Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector2d GetMinBound() const override;
     Eigen::Vector2d GetMaxBound() const override;
     bool TestImageBoundary(double u, double v, double inner_margin = 0.0) const;
 
-  public:
+public:
     virtual bool HasData() const {
         return width_ > 0 && height_ > 0 &&
                data_.size() == height_ * BytesPerLine();
@@ -88,12 +88,12 @@ class Image : public Geometry2D {
     /// (single-channel) float image
     std::pair<bool, double> FloatValueAt(double u, double v) const;
 
-  protected:
+protected:
     void AllocateDataBuffer() {
         data_.resize(width_ * height_ * num_of_channels_ * bytes_per_channel_);
     }
 
-  public:
+public:
     int width_ = 0;
     int height_ = 0;
     int num_of_channels_ = 0;

--- a/src/Core/Geometry/KDTreeFlann.h
+++ b/src/Core/Geometry/KDTreeFlann.h
@@ -46,7 +46,7 @@ class Index;
 namespace open3d {
 
 class KDTreeFlann {
-  public:
+public:
     KDTreeFlann();
     KDTreeFlann(const Eigen::MatrixXd &data);
     KDTreeFlann(const Geometry &geometry);
@@ -55,7 +55,7 @@ class KDTreeFlann {
     KDTreeFlann(const KDTreeFlann &) = delete;
     KDTreeFlann &operator=(const KDTreeFlann &) = delete;
 
-  public:
+public:
     bool SetMatrixData(const Eigen::MatrixXd &data);
     bool SetGeometry(const Geometry &geometry);
     bool SetFeature(const Feature &feature);
@@ -85,10 +85,10 @@ class KDTreeFlann {
                      std::vector<int> &indices,
                      std::vector<double> &distance2) const;
 
-  private:
+private:
     bool SetRawData(const Eigen::Map<const Eigen::MatrixXd> &data);
 
-  protected:
+protected:
     std::vector<double> data_;
     std::unique_ptr<flann::Matrix<double>> flann_dataset_;
     std::unique_ptr<flann::Index<flann::L2<double>>> flann_index_;

--- a/src/Core/Geometry/KDTreeSearchParam.h
+++ b/src/Core/Geometry/KDTreeSearchParam.h
@@ -29,52 +29,52 @@
 namespace open3d {
 
 class KDTreeSearchParam {
-  public:
+public:
     enum class SearchType {
         Knn = 0,
         Radius = 1,
         Hybrid = 2,
     };
 
-  public:
+public:
     virtual ~KDTreeSearchParam() {}
 
-  protected:
+protected:
     KDTreeSearchParam(SearchType type) : search_type_(type) {}
 
-  public:
+public:
     SearchType GetSearchType() const { return search_type_; }
 
-  private:
+private:
     SearchType search_type_;
 };
 
 class KDTreeSearchParamKNN : public KDTreeSearchParam {
-  public:
+public:
     KDTreeSearchParamKNN(int knn = 30)
         : KDTreeSearchParam(SearchType::Knn), knn_(knn) {}
 
-  public:
+public:
     int knn_;
 };
 
 class KDTreeSearchParamRadius : public KDTreeSearchParam {
-  public:
+public:
     KDTreeSearchParamRadius(double radius)
         : KDTreeSearchParam(SearchType::Radius), radius_(radius) {}
 
-  public:
+public:
     double radius_;
 };
 
 class KDTreeSearchParamHybrid : public KDTreeSearchParam {
-  public:
+public:
     KDTreeSearchParamHybrid(double radius, int max_nn)
         : KDTreeSearchParam(SearchType::Hybrid),
           radius_(radius),
           max_nn_(max_nn) {}
 
-  public:
+public:
     double radius_;
     int max_nn_;
 };

--- a/src/Core/Geometry/LineSet.h
+++ b/src/Core/Geometry/LineSet.h
@@ -36,22 +36,22 @@ namespace open3d {
 class PointCloud;
 
 class LineSet : public Geometry3D {
-  public:
+public:
     LineSet() : Geometry3D(Geometry::GeometryType::LineSet) {}
     ~LineSet() override {}
 
-  public:
+public:
     void Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
     void Transform(const Eigen::Matrix4d &transformation) override;
 
-  public:
+public:
     LineSet &operator+=(const LineSet &lineset);
     LineSet operator+(const LineSet &lineset) const;
 
-  public:
+public:
     bool HasPoints() const { return points_.size() > 0; }
 
     bool HasLines() const { return HasPoints() && lines_.size() > 0; }
@@ -65,7 +65,7 @@ class LineSet : public Geometry3D {
         return std::make_pair(points_[lines_[i][0]], points_[lines_[i][1]]);
     }
 
-  public:
+public:
     std::vector<Eigen::Vector3d> points_;
     std::vector<Eigen::Vector2i> lines_;
     std::vector<Eigen::Vector3d> colors_;

--- a/src/Core/Geometry/PointCloud.h
+++ b/src/Core/Geometry/PointCloud.h
@@ -40,22 +40,22 @@ class RGBDImage;
 class PinholeCameraIntrinsic;
 
 class PointCloud : public Geometry3D {
-  public:
+public:
     PointCloud() : Geometry3D(Geometry::GeometryType::PointCloud){};
     ~PointCloud() override{};
 
-  public:
+public:
     void Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
     void Transform(const Eigen::Matrix4d &transformation) override;
 
-  public:
+public:
     PointCloud &operator+=(const PointCloud &cloud);
     PointCloud operator+(const PointCloud &cloud) const;
 
-  public:
+public:
     bool HasPoints() const { return points_.size() > 0; }
 
     bool HasNormals() const {
@@ -79,7 +79,7 @@ class PointCloud : public Geometry3D {
         }
     }
 
-  public:
+public:
     std::vector<Eigen::Vector3d> points_;
     std::vector<Eigen::Vector3d> normals_;
     std::vector<Eigen::Vector3d> colors_;

--- a/src/Core/Geometry/RGBDImage.h
+++ b/src/Core/Geometry/RGBDImage.h
@@ -35,7 +35,7 @@ namespace open3d {
 /// viewed from the same view, of the same resolution.
 /// If you have other format, convert it first.
 class RGBDImage {
-  public:
+public:
     RGBDImage(){};
     RGBDImage(const Image &color, const Image &depth)
         : color_(color), depth_(depth){};
@@ -44,7 +44,7 @@ class RGBDImage {
         depth_.Clear();
     };
 
-  public:
+public:
     Image color_;
     Image depth_;
 };

--- a/src/Core/Geometry/TriangleMesh.h
+++ b/src/Core/Geometry/TriangleMesh.h
@@ -35,18 +35,18 @@
 namespace open3d {
 
 class TriangleMesh : public Geometry3D {
-  public:
+public:
     TriangleMesh() : Geometry3D(Geometry::GeometryType::TriangleMesh){};
     ~TriangleMesh() override{};
 
-  public:
+public:
     void Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
     void Transform(const Eigen::Matrix4d &transformation) override;
 
-  public:
+public:
     TriangleMesh &operator+=(const TriangleMesh &mesh);
     TriangleMesh operator+(const TriangleMesh &mesh) const;
 
@@ -59,13 +59,13 @@ class TriangleMesh : public Geometry3D {
     /// Function to remove duplicated and non-manifold vertices/triangles
     void Purge();
 
-  protected:
+protected:
     void RemoveDuplicatedVertices();
     void RemoveDuplicatedTriangles();
     void RemoveNonManifoldVertices();
     void RemoveNonManifoldTriangles();
 
-  public:
+public:
     bool HasVertices() const { return vertices_.size() > 0; }
 
     bool HasTriangles() const {
@@ -108,7 +108,7 @@ class TriangleMesh : public Geometry3D {
         }
     }
 
-  public:
+public:
     std::vector<Eigen::Vector3d> vertices_;
     std::vector<Eigen::Vector3d> vertex_normals_;
     std::vector<Eigen::Vector3d> vertex_colors_;

--- a/src/Core/Geometry/VoxelGrid.h
+++ b/src/Core/Geometry/VoxelGrid.h
@@ -37,29 +37,29 @@ class PointCloud;
 class TriangleMesh;
 
 class VoxelGrid : public Geometry3D {
-  public:
+public:
     VoxelGrid() : Geometry3D(Geometry::GeometryType::VoxelGrid){};
     ~VoxelGrid() override{};
 
-  public:
+public:
     void Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
     void Transform(const Eigen::Matrix4d &transformation) override;
 
-  public:
+public:
     VoxelGrid &operator+=(const VoxelGrid &voxelgrid);
     VoxelGrid operator+(const VoxelGrid &voxelgrid) const;
 
-  public:
+public:
     bool HasVoxels() const { return voxels_.size() > 0; }
 
     bool HasColors() const {
         return voxels_.size() > 0 && colors_.size() == voxels_.size();
     }
 
-  public:
+public:
     double voxel_size_;
     Eigen::Vector3d origin_;
     std::vector<Eigen::Vector3i> voxels_;

--- a/src/Core/Geometry/VoxelGridFactory.cpp
+++ b/src/Core/Geometry/VoxelGridFactory.cpp
@@ -38,10 +38,10 @@ namespace open3d {
 namespace {
 
 class PointCloudVoxel {
-  public:
+public:
     PointCloudVoxel() : num_of_points_(0), color_(0.0, 0.0, 0.0) {}
 
-  public:
+public:
     void AddPoint(const Eigen::Vector3i &voxel_index,
                   const PointCloud &cloud,
                   int index) {
@@ -58,7 +58,7 @@ class PointCloudVoxel {
         return color_ / double(num_of_points_);
     }
 
-  public:
+public:
     int num_of_points_;
     Eigen::Vector3i coordinate_;
     Eigen::Vector3d color_;

--- a/src/Core/Integration/ScalableTSDFVolume.h
+++ b/src/Core/Integration/ScalableTSDFVolume.h
@@ -54,17 +54,17 @@ class UniformTSDFVolume;
 /// structure edges.
 
 class ScalableTSDFVolume : public TSDFVolume {
-  public:
+public:
     struct VolumeUnit {
-      public:
+    public:
         VolumeUnit() : volume_(NULL) {}
 
-      public:
+    public:
         std::shared_ptr<UniformTSDFVolume> volume_;
         Eigen::Vector3i index_;
     };
 
-  public:
+public:
     ScalableTSDFVolume(double voxel_length,
                        double sdf_trunc,
                        TSDFVolumeColorType color_type,
@@ -72,7 +72,7 @@ class ScalableTSDFVolume : public TSDFVolume {
                        int depth_sampling_stride = 4);
     ~ScalableTSDFVolume() override;
 
-  public:
+public:
     void Reset() override;
     void Integrate(const RGBDImage &image,
                    const PinholeCameraIntrinsic &intrinsic,
@@ -81,7 +81,7 @@ class ScalableTSDFVolume : public TSDFVolume {
     std::shared_ptr<TriangleMesh> ExtractTriangleMesh() override;
     std::shared_ptr<PointCloud> ExtractVoxelPointCloud();
 
-  public:
+public:
     int volume_unit_resolution_;
     double volume_unit_length_;
     int depth_sampling_stride_;
@@ -94,7 +94,7 @@ class ScalableTSDFVolume : public TSDFVolume {
                        hash_eigen::hash<Eigen::Vector3i>>
             volume_units_;
 
-  private:
+private:
     Eigen::Vector3i LocateVolumeUnit(const Eigen::Vector3d &point) {
         return Eigen::Vector3i((int)std::floor(point(0) / volume_unit_length_),
                                (int)std::floor(point(1) / volume_unit_length_),

--- a/src/Core/Integration/TSDFVolume.h
+++ b/src/Core/Integration/TSDFVolume.h
@@ -47,7 +47,7 @@ enum class TSDFVolumeColorType {
 /// A volumetric method for building complex models from range images
 /// In SIGGRAPH, 1996
 class TSDFVolume {
-  public:
+public:
     TSDFVolume(double voxel_length,
                double sdf_trunc,
                TSDFVolumeColorType color_type)
@@ -56,7 +56,7 @@ class TSDFVolume {
           color_type_(color_type) {}
     virtual ~TSDFVolume() {}
 
-  public:
+public:
     /// Function to reset the TSDFVolume
     virtual void Reset() = 0;
 
@@ -73,7 +73,7 @@ class TSDFVolume {
     /// (https://en.wikipedia.org/wiki/Marching_cubes)
     virtual std::shared_ptr<TriangleMesh> ExtractTriangleMesh() = 0;
 
-  public:
+public:
     double voxel_length_;
     double sdf_trunc_;
     TSDFVolumeColorType color_type_;

--- a/src/Core/Integration/UniformTSDFVolume.h
+++ b/src/Core/Integration/UniformTSDFVolume.h
@@ -31,7 +31,7 @@
 namespace open3d {
 
 class UniformTSDFVolume : public TSDFVolume {
-  public:
+public:
     UniformTSDFVolume(double length,
                       int resolution,
                       double sdf_trunc,
@@ -39,7 +39,7 @@ class UniformTSDFVolume : public TSDFVolume {
                       const Eigen::Vector3d &origin = Eigen::Vector3d::Zero());
     ~UniformTSDFVolume() override;
 
-  public:
+public:
     void Reset() override;
     void Integrate(const RGBDImage &image,
                    const PinholeCameraIntrinsic &intrinsic,
@@ -66,7 +66,7 @@ class UniformTSDFVolume : public TSDFVolume {
         return IndexOf(xyz(0), xyz(1), xyz(2));
     }
 
-  public:
+public:
     Eigen::Vector3d origin_;
     double length_;
     int resolution_;
@@ -75,7 +75,7 @@ class UniformTSDFVolume : public TSDFVolume {
     std::vector<Eigen::Vector3f> color_;
     std::vector<float> weight_;
 
-  private:
+private:
     Eigen::Vector3d GetNormalAt(const Eigen::Vector3d &p);
 
     double GetTSDFAt(const Eigen::Vector3d &p);

--- a/src/Core/Odometry/OdometryOption.h
+++ b/src/Core/Odometry/OdometryOption.h
@@ -31,7 +31,7 @@
 namespace open3d {
 
 class OdometryOption {
-  public:
+public:
     OdometryOption(
             const std::vector<int> &iteration_number_per_pyramid_level =
                     {20, 10,
@@ -46,7 +46,7 @@ class OdometryOption {
           max_depth_(max_depth) {}
     ~OdometryOption() {}
 
-  public:
+public:
     std::vector<int> iteration_number_per_pyramid_level_;
     double max_depth_diff_;
     double min_depth_;

--- a/src/Core/Odometry/RGBDOdometryJacobian.h
+++ b/src/Core/Odometry/RGBDOdometryJacobian.h
@@ -44,11 +44,11 @@ typedef std::vector<Eigen::Vector4i, Vector4i_allocator>
 
 /// Base class that computes Jacobian from two RGB-D images
 class RGBDOdometryJacobian {
-  public:
+public:
     RGBDOdometryJacobian() {}
     virtual ~RGBDOdometryJacobian() {}
 
-  public:
+public:
     /// Function to compute i-th row of J and r
     /// the vector form of J_r is basically 6x1 matrix, but it can be
     /// easily extendable to 6xn matrix.
@@ -74,11 +74,11 @@ class RGBDOdometryJacobian {
 /// Real-time visual odometry from dense RGB-D images.
 /// In ICCV Workshops, 2011.
 class RGBDOdometryJacobianFromColorTerm : public RGBDOdometryJacobian {
-  public:
+public:
     RGBDOdometryJacobianFromColorTerm() {}
     ~RGBDOdometryJacobianFromColorTerm() override {}
 
-  public:
+public:
     void ComputeJacobianAndResidual(
             int row,
             std::vector<Eigen::Vector6d, Vector6d_allocator> &J_r,
@@ -99,11 +99,11 @@ class RGBDOdometryJacobianFromColorTerm : public RGBDOdometryJacobian {
 /// J. Park, Q.-Y. Zhou, and V. Koltun
 /// anonymous submission
 class RGBDOdometryJacobianFromHybridTerm : public RGBDOdometryJacobian {
-  public:
+public:
     RGBDOdometryJacobianFromHybridTerm() {}
     ~RGBDOdometryJacobianFromHybridTerm() override {}
 
-  public:
+public:
     void ComputeJacobianAndResidual(
             int row,
             std::vector<Eigen::Vector6d, Vector6d_allocator> &J_r,

--- a/src/Core/Registration/ColoredICP.cpp
+++ b/src/Core/Registration/ColoredICP.cpp
@@ -40,12 +40,12 @@ namespace open3d {
 namespace {
 
 class PointCloudForColoredICP : public PointCloud {
-  public:
+public:
     std::vector<Eigen::Vector3d> color_gradient_;
 };
 
 class TransformationEstimationForColoredICP : public TransformationEstimation {
-  public:
+public:
     TransformationEstimationType GetTransformationEstimationType()
             const override {
         return type_;
@@ -57,7 +57,7 @@ class TransformationEstimationForColoredICP : public TransformationEstimation {
     }
     ~TransformationEstimationForColoredICP() override {}
 
-  public:
+public:
     double ComputeRMSE(const PointCloud &source,
                        const PointCloud &target,
                        const CorrespondenceSet &corres) const override;
@@ -66,10 +66,10 @@ class TransformationEstimationForColoredICP : public TransformationEstimation {
             const PointCloud &target,
             const CorrespondenceSet &corres) const override;
 
-  public:
+public:
     double lambda_geometric_;
 
-  private:
+private:
     const TransformationEstimationType type_ =
             TransformationEstimationType::ColoredICP;
 };

--- a/src/Core/Registration/CorrespondenceChecker.h
+++ b/src/Core/Registration/CorrespondenceChecker.h
@@ -42,12 +42,12 @@ class PointCloud;
 /// FastGlobalRegistration) to prune out outlier correspondences.
 /// The virtual function Check() must be implemented in subclasses.
 class CorrespondenceChecker {
-  public:
+public:
     CorrespondenceChecker(bool require_pointcloud_alignment)
         : require_pointcloud_alignment_(require_pointcloud_alignment) {}
     virtual ~CorrespondenceChecker() {}
 
-  public:
+public:
     /// Function to check if two points can be aligned. The two input point
     /// clouds must have exact the same number of points.
     virtual bool Check(const PointCloud &source,
@@ -55,7 +55,7 @@ class CorrespondenceChecker {
                        const CorrespondenceSet &corres,
                        const Eigen::Matrix4d &transformation) const = 0;
 
-  public:
+public:
     /// Some checkers do not require point clouds to be aligned, e.g., the edge
     /// length checker. Some checkers do, e.g., the distance checker.
     bool require_pointcloud_alignment_;
@@ -65,55 +65,55 @@ class CorrespondenceChecker {
 /// The only parameter similarity_threshold is a number between 0 (loose) and 1
 /// (strict).
 class CorrespondenceCheckerBasedOnEdgeLength : public CorrespondenceChecker {
-  public:
+public:
     CorrespondenceCheckerBasedOnEdgeLength(double similarity_threshold = 0.9)
         : CorrespondenceChecker(false),
           similarity_threshold_(similarity_threshold) {}
     ~CorrespondenceCheckerBasedOnEdgeLength() override {}
 
-  public:
+public:
     bool Check(const PointCloud &source,
                const PointCloud &target,
                const CorrespondenceSet &corres,
                const Eigen::Matrix4d &transformation) const override;
 
-  public:
+public:
     double similarity_threshold_;
 };
 
 /// Check if two aligned point clouds are close
 class CorrespondenceCheckerBasedOnDistance : public CorrespondenceChecker {
-  public:
+public:
     CorrespondenceCheckerBasedOnDistance(double distance_threshold)
         : CorrespondenceChecker(true),
           distance_threshold_(distance_threshold) {}
     ~CorrespondenceCheckerBasedOnDistance() override {}
 
-  public:
+public:
     bool Check(const PointCloud &source,
                const PointCloud &target,
                const CorrespondenceSet &corres,
                const Eigen::Matrix4d &transformation) const override;
 
-  public:
+public:
     double distance_threshold_;
 };
 
 /// Check if two aligned point clouds have similar normals
 class CorrespondenceCheckerBasedOnNormal : public CorrespondenceChecker {
-  public:
+public:
     CorrespondenceCheckerBasedOnNormal(double normal_angle_threshold)
         : CorrespondenceChecker(true),
           normal_angle_threshold_(normal_angle_threshold) {}
     ~CorrespondenceCheckerBasedOnNormal() override {}
 
-  public:
+public:
     bool Check(const PointCloud &source,
                const PointCloud &target,
                const CorrespondenceSet &corres,
                const Eigen::Matrix4d &transformation) const override;
 
-  public:
+public:
     double normal_angle_threshold_;
 };
 

--- a/src/Core/Registration/FastGlobalRegistration.h
+++ b/src/Core/Registration/FastGlobalRegistration.h
@@ -39,7 +39,7 @@ class Feature;
 class RegistrationResult;
 
 class FastGlobalRegistrationOption {
-  public:
+public:
     FastGlobalRegistrationOption(double division_factor = 1.4,
                                  bool use_absolute_scale = false,
                                  bool decrease_mu = true,
@@ -54,7 +54,7 @@ class FastGlobalRegistrationOption {
           maximum_tuple_count_(maximum_tuple_count) {}
     ~FastGlobalRegistrationOption() {}
 
-  public:
+public:
     // Division factor used for graduated non-convexity
     double division_factor_;
     // Measure distance in absolute scale (1) or in scale relative to the

--- a/src/Core/Registration/Feature.h
+++ b/src/Core/Registration/Feature.h
@@ -36,7 +36,7 @@ namespace open3d {
 class PointCloud;
 
 class Feature {
-  public:
+public:
     void Resize(int dim, int n) {
         data_.resize(dim, n);
         data_.setZero();
@@ -44,7 +44,7 @@ class Feature {
     size_t Dimension() const { return data_.rows(); }
     size_t Num() const { return data_.cols(); }
 
-  public:
+public:
     Eigen::MatrixXd data_;
 };
 

--- a/src/Core/Registration/GlobalOptimizationConvergenceCriteria.h
+++ b/src/Core/Registration/GlobalOptimizationConvergenceCriteria.h
@@ -29,7 +29,7 @@
 namespace open3d {
 
 class GlobalOptimizationOption {
-  public:
+public:
     GlobalOptimizationOption(double max_correspondence_distance = 0.075,
                              double edge_prune_threshold = 0.25,
                              double preference_loop_closure = 1.0,
@@ -50,7 +50,7 @@ class GlobalOptimizationOption {
     };
     ~GlobalOptimizationOption(){};
 
-  public:
+public:
     /// See reference list in GlobalOptimization.h
     /// Identifies which distance value is used for finding neighboring points
     /// when making information matrix. According to [Choi et al 2015],
@@ -69,7 +69,7 @@ class GlobalOptimizationOption {
 };
 
 class GlobalOptimizationConvergenceCriteria {
-  public:
+public:
     GlobalOptimizationConvergenceCriteria(
             int max_iteration = 100,
             double min_relative_increment = 1e-6,
@@ -98,7 +98,7 @@ class GlobalOptimizationConvergenceCriteria {
     };
     ~GlobalOptimizationConvergenceCriteria(){};
 
-  public:
+public:
     /// maximum iteration number for iterative optmization module.
     int max_iteration_;
     /// several convergence criteria to determine

--- a/src/Core/Registration/GlobalOptimizationMethod.h
+++ b/src/Core/Registration/GlobalOptimizationMethod.h
@@ -39,11 +39,11 @@ class GlobalOptimizationConvergenceCriteria;
 class GlobalOptimizationOption;
 
 class GlobalOptimizationMethod {
-  public:
+public:
     GlobalOptimizationMethod() {}
     virtual ~GlobalOptimizationMethod() {}
 
-  public:
+public:
     virtual void OptimizePoseGraph(
             PoseGraph &pose_graph,
             const GlobalOptimizationConvergenceCriteria &criteria,
@@ -51,11 +51,11 @@ class GlobalOptimizationMethod {
 };
 
 class GlobalOptimizationGaussNewton : public GlobalOptimizationMethod {
-  public:
+public:
     GlobalOptimizationGaussNewton() {}
     ~GlobalOptimizationGaussNewton() override {}
 
-  public:
+public:
     void OptimizePoseGraph(
             PoseGraph &pose_graph,
             const GlobalOptimizationConvergenceCriteria &criteria,
@@ -63,11 +63,11 @@ class GlobalOptimizationGaussNewton : public GlobalOptimizationMethod {
 };
 
 class GlobalOptimizationLevenbergMarquardt : public GlobalOptimizationMethod {
-  public:
+public:
     GlobalOptimizationLevenbergMarquardt() {}
     ~GlobalOptimizationLevenbergMarquardt() override {}
 
-  public:
+public:
     void OptimizePoseGraph(
             PoseGraph &pose_graph,
             const GlobalOptimizationConvergenceCriteria &criteria,

--- a/src/Core/Registration/PoseGraph.h
+++ b/src/Core/Registration/PoseGraph.h
@@ -35,21 +35,21 @@
 namespace open3d {
 
 class PoseGraphNode : public IJsonConvertible {
-  public:
+public:
     PoseGraphNode(const Eigen::Matrix4d &pose = Eigen::Matrix4d::Identity())
         : pose_(pose){};
     ~PoseGraphNode();
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     Eigen::Matrix4d_u pose_;
 };
 
 class PoseGraphEdge : public IJsonConvertible {
-  public:
+public:
     PoseGraphEdge(
             int source_node_id = -1,
             int target_node_id = -1,
@@ -65,11 +65,11 @@ class PoseGraphEdge : public IJsonConvertible {
           confidence_(confidence){};
     ~PoseGraphEdge();
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     int source_node_id_;
     int target_node_id_;
     Eigen::Matrix4d_u transformation_;
@@ -85,15 +85,15 @@ class PoseGraphEdge : public IJsonConvertible {
 };
 
 class PoseGraph : public IJsonConvertible {
-  public:
+public:
     PoseGraph();
     ~PoseGraph() override;
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     std::vector<PoseGraphNode> nodes_;
     std::vector<PoseGraphEdge> edges_;
 };

--- a/src/Core/Registration/Registration.h
+++ b/src/Core/Registration/Registration.h
@@ -44,7 +44,7 @@ class Feature;
 /// relative_fitness_ and relative_rmse_ individually, or the iteration number
 /// exceeds max_iteration_.
 class ICPConvergenceCriteria {
-  public:
+public:
     ICPConvergenceCriteria(double relative_fitness = 1e-6,
                            double relative_rmse = 1e-6,
                            int max_iteration = 30)
@@ -53,7 +53,7 @@ class ICPConvergenceCriteria {
           max_iteration_(max_iteration) {}
     ~ICPConvergenceCriteria() {}
 
-  public:
+public:
     double relative_fitness_;
     double relative_rmse_;
     int max_iteration_;
@@ -66,26 +66,26 @@ class ICPConvergenceCriteria {
 /// iteration. Most iterations do not do full validation. It is crucial to
 /// control max_validation_ so that the computation time is acceptable.
 class RANSACConvergenceCriteria {
-  public:
+public:
     RANSACConvergenceCriteria(int max_iteration = 1000,
                               int max_validation = 1000)
         : max_iteration_(max_iteration), max_validation_(max_validation) {}
     ~RANSACConvergenceCriteria() {}
 
-  public:
+public:
     int max_iteration_;
     int max_validation_;
 };
 
 /// Class that contains the registration result
 class RegistrationResult {
-  public:
+public:
     RegistrationResult(
             const Eigen::Matrix4d &transformation = Eigen::Matrix4d::Identity())
         : transformation_(transformation), inlier_rmse_(0.0), fitness_(0.0) {}
     ~RegistrationResult() {}
 
-  public:
+public:
     Eigen::Matrix4d_u transformation_;
     CorrespondenceSet correspondence_set_;
     double inlier_rmse_;

--- a/src/Core/Registration/TransformationEstimation.h
+++ b/src/Core/Registration/TransformationEstimation.h
@@ -48,11 +48,11 @@ enum class TransformationEstimationType {
 /// The virtual function ComputeTransformation() must be implemented in
 /// subclasses.
 class TransformationEstimation {
-  public:
+public:
     TransformationEstimation() {}
     virtual ~TransformationEstimation() {}
 
-  public:
+public:
     virtual TransformationEstimationType GetTransformationEstimationType()
             const = 0;
     virtual double ComputeRMSE(const PointCloud &source,
@@ -66,12 +66,12 @@ class TransformationEstimation {
 
 /// Estimate a transformation for point to point distance
 class TransformationEstimationPointToPoint : public TransformationEstimation {
-  public:
+public:
     TransformationEstimationPointToPoint(bool with_scaling = false)
         : with_scaling_(with_scaling) {}
     ~TransformationEstimationPointToPoint() override {}
 
-  public:
+public:
     TransformationEstimationType GetTransformationEstimationType()
             const override {
         return type_;
@@ -84,21 +84,21 @@ class TransformationEstimationPointToPoint : public TransformationEstimation {
             const PointCloud &target,
             const CorrespondenceSet &corres) const override;
 
-  public:
+public:
     bool with_scaling_ = false;
 
-  private:
+private:
     const TransformationEstimationType type_ =
             TransformationEstimationType::PointToPoint;
 };
 
 /// Estimate a transformation for point to plane distance
 class TransformationEstimationPointToPlane : public TransformationEstimation {
-  public:
+public:
     TransformationEstimationPointToPlane() {}
     ~TransformationEstimationPointToPlane() override {}
 
-  public:
+public:
     TransformationEstimationType GetTransformationEstimationType()
             const override {
         return type_;
@@ -111,7 +111,7 @@ class TransformationEstimationPointToPlane : public TransformationEstimation {
             const PointCloud &target,
             const CorrespondenceSet &corres) const override;
 
-  private:
+private:
     const TransformationEstimationType type_ =
             TransformationEstimationType::PointToPlane;
 };

--- a/src/Core/Utility/IJsonConvertible.h
+++ b/src/Core/Utility/IJsonConvertible.h
@@ -38,14 +38,14 @@ namespace open3d {
 /// Class IJsonConvertible defines the behavior of a class that can convert
 /// itself to/from a json::Value.
 class IJsonConvertible {
-  public:
+public:
     virtual ~IJsonConvertible() {}
 
-  public:
+public:
     virtual bool ConvertToJsonValue(Json::Value &value) const = 0;
     virtual bool ConvertFromJsonValue(const Json::Value &value) = 0;
 
-  public:
+public:
     static bool EigenVector3dFromJsonArray(Eigen::Vector3d &vec,
                                            const Json::Value &value);
     static bool EigenVector3dToJsonArray(const Eigen::Vector3d &vec,

--- a/src/Core/Utility/Timer.h
+++ b/src/Core/Utility/Timer.h
@@ -31,35 +31,35 @@
 namespace open3d {
 
 class Timer {
-  public:
+public:
     Timer();
     ~Timer();
 
-  public:
+public:
     static double GetSystemTimeInMilliseconds();
 
-  public:
+public:
     void Start();
     void Stop();
     void Print(const std::string &timer_info) const;
     double GetDuration() const;
 
-  private:
+private:
     double start_time_in_milliseconds_;
     double end_time_in_milliseconds_;
 };
 
 class ScopeTimer : public Timer {
-  public:
+public:
     ScopeTimer(const std::string &scope_timer_info = "");
     ~ScopeTimer();
 
-  private:
+private:
     std::string scope_timer_info_;
 };
 
 class FPSTimer : public Timer {
-  public:
+public:
     FPSTimer(const std::string &fps_timer_info = "",
              int expectation = -1,
              double time_to_print = 3000.0,
@@ -70,7 +70,7 @@ class FPSTimer : public Timer {
     /// time_to_print_, or event has been signaled events_to_print_ times.
     void Signal();
 
-  private:
+private:
     std::string fps_timer_info_;
     int expectation_;
     double time_to_print_;

--- a/src/IO/FileFormat/FilePCD.cpp
+++ b/src/IO/FileFormat/FilePCD.cpp
@@ -49,7 +49,7 @@ enum PCDDataType {
 };
 
 struct PCLPointField {
-  public:
+public:
     std::string name;
     int size;
     char type;
@@ -60,7 +60,7 @@ struct PCLPointField {
 };
 
 struct PCDHeader {
-  public:
+public:
     std::string version;
     std::vector<PCLPointField> fields;
     int width;

--- a/src/Python/Core/open3d_core_trampoline.h
+++ b/src/Python/Core/open3d_core_trampoline.h
@@ -34,7 +34,7 @@ using namespace open3d;
 
 template <class GeometryBase = Geometry>
 class PyGeometry : public GeometryBase {
-  public:
+public:
     using GeometryBase::GeometryBase;
     void Clear() override { PYBIND11_OVERLOAD_PURE(void, GeometryBase, ); }
     bool IsEmpty() const override {
@@ -44,7 +44,7 @@ class PyGeometry : public GeometryBase {
 
 template <class Geometry3DBase = Geometry3D>
 class PyGeometry3D : public PyGeometry<Geometry3DBase> {
-  public:
+public:
     using PyGeometry<Geometry3DBase>::PyGeometry;
     Eigen::Vector3d GetMinBound() const override {
         PYBIND11_OVERLOAD_PURE(Eigen::Vector3d, Geometry3DBase, );
@@ -59,7 +59,7 @@ class PyGeometry3D : public PyGeometry<Geometry3DBase> {
 
 template <class Geometry2DBase = Geometry2D>
 class PyGeometry2D : public PyGeometry<Geometry2DBase> {
-  public:
+public:
     using PyGeometry<Geometry2DBase>::PyGeometry;
     Eigen::Vector2d GetMinBound() const override {
         PYBIND11_OVERLOAD_PURE(Eigen::Vector2d, Geometry2DBase, );

--- a/src/Python/Core/open3d_global_optimization.cpp
+++ b/src/Python/Core/open3d_global_optimization.cpp
@@ -37,7 +37,7 @@ using namespace open3d;
 
 template <class GlobalOptimizationMethodBase = GlobalOptimizationMethod>
 class PyGlobalOptimizationMethod : public GlobalOptimizationMethodBase {
-  public:
+public:
     using GlobalOptimizationMethodBase::GlobalOptimizationMethodBase;
     void OptimizePoseGraph(
             PoseGraph &pose_graph,

--- a/src/Python/Core/open3d_integration.cpp
+++ b/src/Python/Core/open3d_integration.cpp
@@ -35,7 +35,7 @@ using namespace open3d;
 
 template <class TSDFVolumeBase = TSDFVolume>
 class PyTSDFVolume : public TSDFVolumeBase {
-  public:
+public:
     using TSDFVolumeBase::TSDFVolumeBase;
     void Reset() override { PYBIND11_OVERLOAD_PURE(void, TSDFVolumeBase, ); }
     void Integrate(const RGBDImage &image,

--- a/src/Python/Core/open3d_odometry.cpp
+++ b/src/Python/Core/open3d_odometry.cpp
@@ -36,7 +36,7 @@ using namespace open3d;
 
 template <class RGBDOdometryJacobianBase = RGBDOdometryJacobian>
 class PyRGBDOdometryJacobian : public RGBDOdometryJacobianBase {
-  public:
+public:
     using RGBDOdometryJacobianBase::RGBDOdometryJacobianBase;
     void ComputeJacobianAndResidual(
             int row,

--- a/src/Python/Core/open3d_registration.cpp
+++ b/src/Python/Core/open3d_registration.cpp
@@ -39,7 +39,7 @@ using namespace open3d;
 
 template <class TransformationEstimationBase = TransformationEstimation>
 class PyTransformationEstimation : public TransformationEstimationBase {
-  public:
+public:
     using TransformationEstimationBase::TransformationEstimationBase;
     TransformationEstimationType GetTransformationEstimationType()
             const override {
@@ -63,7 +63,7 @@ class PyTransformationEstimation : public TransformationEstimationBase {
 
 template <class CorrespondenceCheckerBase = CorrespondenceChecker>
 class PyCorrespondenceChecker : public CorrespondenceCheckerBase {
-  public:
+public:
     using CorrespondenceCheckerBase::CorrespondenceCheckerBase;
     bool Check(const PointCloud &source,
                const PointCloud &target,

--- a/src/Python/Visualization/open3d_visualization_trampoline.h
+++ b/src/Python/Visualization/open3d_visualization_trampoline.h
@@ -34,7 +34,7 @@ using namespace open3d;
 
 template <class VisualizerBase = Visualizer>
 class PyVisualizer : public VisualizerBase {
-  public:
+public:
     using VisualizerBase::VisualizerBase;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override {
         PYBIND11_OVERLOAD(bool, VisualizerBase, AddGeometry, geometry_ptr);
@@ -61,7 +61,7 @@ class PyVisualizer : public VisualizerBase {
 
 template <class ViewControlBase = ViewControl>
 class PyViewControl : public ViewControlBase {
-  public:
+public:
     using ViewControlBase::ViewControlBase;
     void Reset() override { PYBIND11_OVERLOAD(void, ViewControlBase, Reset, ); }
     void ChangeFieldOfView(double step) override {

--- a/src/Tools/ManuallyAlignPointCloud/AlignmentSession.h
+++ b/src/Tools/ManuallyAlignPointCloud/AlignmentSession.h
@@ -32,11 +32,11 @@
 namespace open3d {
 
 class AlignmentSession : public IJsonConvertible {
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     std::shared_ptr<PointCloud> source_ptr_;  // Original source pointcloud
     std::shared_ptr<PointCloud> target_ptr_;  // Original target pointcloud
     std::vector<size_t> source_indices_;  // Manually annotated point indices

--- a/src/Tools/ManuallyAlignPointCloud/VisualizerForAlignment.h
+++ b/src/Tools/ManuallyAlignPointCloud/VisualizerForAlignment.h
@@ -33,7 +33,7 @@
 namespace open3d {
 
 class VisualizerForAlignment : public Visualizer {
-  public:
+public:
     VisualizerForAlignment(VisualizerWithEditing &source,
                            VisualizerWithEditing &target,
                            double voxel_size = -1.0,
@@ -52,12 +52,12 @@ class VisualizerForAlignment : public Visualizer {
           default_directory_(directory) {}
     ~VisualizerForAlignment() override {}
 
-  public:
+public:
     void PrintVisualizerHelp() override;
     bool AddSourceAndTarget(std::shared_ptr<PointCloud> source,
                             std::shared_ptr<PointCloud> target);
 
-  protected:
+protected:
     void KeyPressCallback(GLFWwindow *window,
                           int key,
                           int scancode,
@@ -69,7 +69,7 @@ class VisualizerForAlignment : public Visualizer {
     void PrintTransformation();
     void EvaluateAlignmentAndSave(const std::string &filename);
 
-  protected:
+protected:
     VisualizerWithEditing &source_visualizer_;
     VisualizerWithEditing &target_visualizer_;
     double voxel_size_ = -1.0;

--- a/src/UnitTest/Utility/Raw.h
+++ b/src/UnitTest/Utility/Raw.h
@@ -34,33 +34,33 @@
 namespace unit_test {
 // Class for "generating" data.
 class Raw {
-  public:
+public:
     Raw() : index(0), step(1) {}
     Raw(const int &seed)
         : index(abs(seed) % SIZE), step((seed <= 0) ? 1 : seed) {}
 
-  private:
+private:
     // size of the raw data
     static const int SIZE = 1021;
 
     // raw data
     static std::vector<uint8_t> data_;
 
-  public:
+public:
     // low end of the range
     static const uint8_t VMIN = 0;
 
     // high end of the range
     static const uint8_t VMAX = 255;
 
-  private:
+private:
     // step through the raw data
     int step;
 
     // index into the raw data
     int index;
 
-  public:
+public:
     // Get the next value.
     template <class T>
     T Next() {

--- a/src/Visualization/Shader/GeometryRenderer.h
+++ b/src/Visualization/Shader/GeometryRenderer.h
@@ -42,10 +42,10 @@ namespace open3d {
 namespace glsl {
 
 class GeometryRenderer {
-  public:
+public:
     virtual ~GeometryRenderer() {}
 
-  public:
+public:
     virtual bool Render(const RenderOption &option,
                         const ViewControl &view) = 0;
 
@@ -66,21 +66,21 @@ class GeometryRenderer {
     bool IsVisible() const { return is_visible_; }
     void SetVisible(bool visible) { is_visible_ = visible; };
 
-  protected:
+protected:
     std::shared_ptr<const Geometry> geometry_ptr_;
     bool is_visible_ = true;
 };
 
 class PointCloudRenderer : public GeometryRenderer {
-  public:
+public:
     ~PointCloudRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     SimpleShaderForPointCloud simple_point_shader_;
     PhongShaderForPointCloud phong_point_shader_;
     NormalShaderForPointCloud normal_point_shader_;
@@ -88,41 +88,41 @@ class PointCloudRenderer : public GeometryRenderer {
 };
 
 class PointCloudPickingRenderer : public GeometryRenderer {
-  public:
+public:
     ~PointCloudPickingRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     PickingShaderForPointCloud picking_shader_;
 };
 
 class LineSetRenderer : public GeometryRenderer {
-  public:
+public:
     ~LineSetRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     SimpleShaderForLineSet simple_lineset_shader_;
 };
 
 class TriangleMeshRenderer : public GeometryRenderer {
-  public:
+public:
     ~TriangleMeshRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     SimpleShaderForTriangleMesh simple_mesh_shader_;
     PhongShaderForTriangleMesh phong_mesh_shader_;
     NormalShaderForTriangleMesh normal_mesh_shader_;
@@ -130,68 +130,68 @@ class TriangleMeshRenderer : public GeometryRenderer {
 };
 
 class VoxelGridRenderer : public GeometryRenderer {
-  public:
+public:
     ~VoxelGridRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     SimpleShaderForVoxelGrid simple_voxelgrid_shader_;
 };
 
 class ImageRenderer : public GeometryRenderer {
-  public:
+public:
     ~ImageRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     ImageShaderForImage image_shader_;
 };
 
 class CoordinateFrameRenderer : public GeometryRenderer {
-  public:
+public:
     ~CoordinateFrameRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     PhongShaderForTriangleMesh phong_shader_;
 };
 
 class SelectionPolygonRenderer : public GeometryRenderer {
-  public:
+public:
     ~SelectionPolygonRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     Simple2DShaderForSelectionPolygon simple2d_shader_;
     ImageMaskShaderForImage image_mask_shader_;
 };
 
 class PointCloudPickerRenderer : public GeometryRenderer {
-  public:
+public:
     ~PointCloudPickerRenderer() override {}
 
-  public:
+public:
     bool Render(const RenderOption &option, const ViewControl &view) override;
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     bool UpdateGeometry() override;
 
-  protected:
+protected:
     PhongShaderForTriangleMesh phong_shader_;
 };
 

--- a/src/Visualization/Shader/ImageMaskShader.h
+++ b/src/Visualization/Shader/ImageMaskShader.h
@@ -34,15 +34,15 @@ namespace open3d {
 namespace glsl {
 
 class ImageMaskShader : public ShaderWrapper {
-  public:
+public:
     ~ImageMaskShader() override { Release(); }
 
-  protected:
+protected:
     ImageMaskShader(const std::string &name) : ShaderWrapper(name) {
         Compile();
     }
 
-  protected:
+protected:
     bool Compile() final;
     void Release() final;
     bool BindGeometry(const Geometry &geometry,
@@ -53,7 +53,7 @@ class ImageMaskShader : public ShaderWrapper {
                         const ViewControl &view) final;
     void UnbindGeometry() final;
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) = 0;
@@ -62,7 +62,7 @@ class ImageMaskShader : public ShaderWrapper {
                                 const ViewControl &view,
                                 Image &image) = 0;
 
-  protected:
+protected:
     GLuint vertex_position_;
     GLuint vertex_position_buffer_;
     GLuint vertex_UV_;
@@ -77,10 +77,10 @@ class ImageMaskShader : public ShaderWrapper {
 };
 
 class ImageMaskShaderForImage : public ImageMaskShader {
-  public:
+public:
     ImageMaskShaderForImage() : ImageMaskShader("ImageMaskShaderForImage") {}
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) final;

--- a/src/Visualization/Shader/ImageShader.h
+++ b/src/Visualization/Shader/ImageShader.h
@@ -34,13 +34,13 @@ namespace open3d {
 namespace glsl {
 
 class ImageShader : public ShaderWrapper {
-  public:
+public:
     ~ImageShader() override { Release(); }
 
-  protected:
+protected:
     ImageShader(const std::string &name) : ShaderWrapper(name) { Compile(); }
 
-  protected:
+protected:
     bool Compile() final;
     void Release() final;
     bool BindGeometry(const Geometry &geometry,
@@ -51,7 +51,7 @@ class ImageShader : public ShaderWrapper {
                         const ViewControl &view) final;
     void UnbindGeometry() final;
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) = 0;
@@ -60,7 +60,7 @@ class ImageShader : public ShaderWrapper {
                                 const ViewControl &view,
                                 Image &image) = 0;
 
-  protected:
+protected:
     GLuint vertex_position_;
     GLuint vertex_position_buffer_;
     GLuint vertex_UV_;
@@ -73,10 +73,10 @@ class ImageShader : public ShaderWrapper {
 };
 
 class ImageShaderForImage : public ImageShader {
-  public:
+public:
     ImageShaderForImage() : ImageShader("ImageShaderForImage") {}
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) final;

--- a/src/Visualization/Shader/NormalShader.h
+++ b/src/Visualization/Shader/NormalShader.h
@@ -35,13 +35,13 @@ namespace open3d {
 namespace glsl {
 
 class NormalShader : public ShaderWrapper {
-  public:
+public:
     ~NormalShader() override { Release(); }
 
-  protected:
+protected:
     NormalShader(const std::string &name) : ShaderWrapper(name) { Compile(); }
 
-  protected:
+protected:
     bool Compile() final;
     void Release() final;
     bool BindGeometry(const Geometry &geometry,
@@ -52,7 +52,7 @@ class NormalShader : public ShaderWrapper {
                         const ViewControl &view) final;
     void UnbindGeometry() final;
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) = 0;
@@ -62,7 +62,7 @@ class NormalShader : public ShaderWrapper {
                                 std::vector<Eigen::Vector3f> &points,
                                 std::vector<Eigen::Vector3f> &normals) = 0;
 
-  protected:
+protected:
     GLuint vertex_position_;
     GLuint vertex_position_buffer_;
     GLuint vertex_normal_;
@@ -73,10 +73,10 @@ class NormalShader : public ShaderWrapper {
 };
 
 class NormalShaderForPointCloud : public NormalShader {
-  public:
+public:
     NormalShaderForPointCloud() : NormalShader("NormalShaderForPointCloud") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;
@@ -88,11 +88,11 @@ class NormalShaderForPointCloud : public NormalShader {
 };
 
 class NormalShaderForTriangleMesh : public NormalShader {
-  public:
+public:
     NormalShaderForTriangleMesh()
         : NormalShader("NormalShaderForTriangleMesh") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;

--- a/src/Visualization/Shader/PhongShader.h
+++ b/src/Visualization/Shader/PhongShader.h
@@ -35,13 +35,13 @@ namespace open3d {
 namespace glsl {
 
 class PhongShader : public ShaderWrapper {
-  public:
+public:
     ~PhongShader() override { Release(); }
 
-  protected:
+protected:
     PhongShader(const std::string &name) : ShaderWrapper(name) { Compile(); }
 
-  protected:
+protected:
     bool Compile() final;
     void Release() final;
     bool BindGeometry(const Geometry &geometry,
@@ -52,7 +52,7 @@ class PhongShader : public ShaderWrapper {
                         const ViewControl &view) final;
     void UnbindGeometry() final;
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) = 0;
@@ -63,10 +63,10 @@ class PhongShader : public ShaderWrapper {
                                 std::vector<Eigen::Vector3f> &normals,
                                 std::vector<Eigen::Vector3f> &colors) = 0;
 
-  protected:
+protected:
     void SetLighting(const ViewControl &view, const RenderOption &option);
 
-  protected:
+protected:
     GLuint vertex_position_;
     GLuint vertex_position_buffer_;
     GLuint vertex_color_;
@@ -93,10 +93,10 @@ class PhongShader : public ShaderWrapper {
 };
 
 class PhongShaderForPointCloud : public PhongShader {
-  public:
+public:
     PhongShaderForPointCloud() : PhongShader("PhongShaderForPointCloud") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;
@@ -109,10 +109,10 @@ class PhongShaderForPointCloud : public PhongShader {
 };
 
 class PhongShaderForTriangleMesh : public PhongShader {
-  public:
+public:
     PhongShaderForTriangleMesh() : PhongShader("PhongShaderForTriangleMesh") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;

--- a/src/Visualization/Shader/PickingShader.h
+++ b/src/Visualization/Shader/PickingShader.h
@@ -35,13 +35,13 @@ namespace open3d {
 namespace glsl {
 
 class PickingShader : public ShaderWrapper {
-  public:
+public:
     ~PickingShader() override { Release(); }
 
-  protected:
+protected:
     PickingShader(const std::string &name) : ShaderWrapper(name) { Compile(); }
 
-  protected:
+protected:
     bool Compile() final;
     void Release() final;
     bool BindGeometry(const Geometry &geometry,
@@ -52,7 +52,7 @@ class PickingShader : public ShaderWrapper {
                         const ViewControl &view) final;
     void UnbindGeometry() final;
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) = 0;
@@ -62,7 +62,7 @@ class PickingShader : public ShaderWrapper {
                                 std::vector<Eigen::Vector3f> &points,
                                 std::vector<float> &indices) = 0;
 
-  protected:
+protected:
     GLuint vertex_position_;
     GLuint vertex_position_buffer_;
     GLuint vertex_index_;
@@ -71,11 +71,11 @@ class PickingShader : public ShaderWrapper {
 };
 
 class PickingShaderForPointCloud : public PickingShader {
-  public:
+public:
     PickingShaderForPointCloud()
         : PickingShader("PickingShaderForPointCloud") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;

--- a/src/Visualization/Shader/ShaderWrapper.h
+++ b/src/Visualization/Shader/ShaderWrapper.h
@@ -37,15 +37,15 @@ namespace open3d {
 namespace glsl {
 
 class ShaderWrapper {
-  public:
+public:
     virtual ~ShaderWrapper() {}
     ShaderWrapper(const ShaderWrapper &) = delete;
     ShaderWrapper &operator=(const ShaderWrapper &) = delete;
 
-  protected:
+protected:
     ShaderWrapper(const std::string &name) : shader_name_(name) {}
 
-  public:
+public:
     /// Function to render geometry under condition of mode and view
     /// The geometry is updated in a passive manner (bind only when needed).
     /// Thus this function compiles shaders if not yet, binds geometry if not
@@ -62,7 +62,7 @@ class ShaderWrapper {
 
     void PrintShaderWarning(const std::string &message) const;
 
-  protected:
+protected:
     /// Function to compile shader
     /// In a derived class, this must be declared as final, and called from
     /// the constructor.
@@ -81,7 +81,7 @@ class ShaderWrapper {
                                 const ViewControl &view) = 0;
     virtual void UnbindGeometry() = 0;
 
-  protected:
+protected:
     bool ValidateShader(GLuint shader_index);
     bool ValidateProgram(GLuint program_index);
     bool CompileShaders(const char *const vertex_shader_code,
@@ -89,7 +89,7 @@ class ShaderWrapper {
                         const char *const fragment_shader_code);
     void ReleaseProgram();
 
-  protected:
+protected:
     GLuint vertex_shader_;
     GLuint geometry_shader_;
     GLuint fragment_shader_;
@@ -103,7 +103,7 @@ class ShaderWrapper {
         shader_name_ = shader_name;
     }
 
-  private:
+private:
     std::string shader_name_ = "ShaderWrapper";
 };
 

--- a/src/Visualization/Shader/Simple2DShader.h
+++ b/src/Visualization/Shader/Simple2DShader.h
@@ -35,13 +35,13 @@ namespace open3d {
 namespace glsl {
 
 class Simple2DShader : public ShaderWrapper {
-  public:
+public:
     ~Simple2DShader() override { Release(); }
 
-  protected:
+protected:
     Simple2DShader(const std::string &name) : ShaderWrapper(name) { Compile(); }
 
-  protected:
+protected:
     bool Compile() final;
     void Release() final;
     bool BindGeometry(const Geometry &geometry,
@@ -52,7 +52,7 @@ class Simple2DShader : public ShaderWrapper {
                         const ViewControl &view) final;
     void UnbindGeometry() final;
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) = 0;
@@ -62,7 +62,7 @@ class Simple2DShader : public ShaderWrapper {
                                 std::vector<Eigen::Vector3f> &points,
                                 std::vector<Eigen::Vector3f> &colors) = 0;
 
-  protected:
+protected:
     GLuint vertex_position_;
     GLuint vertex_position_buffer_;
     GLuint vertex_color_;
@@ -70,11 +70,11 @@ class Simple2DShader : public ShaderWrapper {
 };
 
 class Simple2DShaderForSelectionPolygon : public Simple2DShader {
-  public:
+public:
     Simple2DShaderForSelectionPolygon()
         : Simple2DShader("Simple2DShaderForSelectionPolygon") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;

--- a/src/Visualization/Shader/SimpleBlackShader.h
+++ b/src/Visualization/Shader/SimpleBlackShader.h
@@ -35,15 +35,15 @@ namespace open3d {
 namespace glsl {
 
 class SimpleBlackShader : public ShaderWrapper {
-  public:
+public:
     ~SimpleBlackShader() override { Release(); }
 
-  protected:
+protected:
     SimpleBlackShader(const std::string &name) : ShaderWrapper(name) {
         Compile();
     }
 
-  protected:
+protected:
     bool Compile() final;
     void Release() final;
     bool BindGeometry(const Geometry &geometry,
@@ -54,7 +54,7 @@ class SimpleBlackShader : public ShaderWrapper {
                         const ViewControl &view) final;
     void UnbindGeometry() final;
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) = 0;
@@ -63,18 +63,18 @@ class SimpleBlackShader : public ShaderWrapper {
                                 const ViewControl &view,
                                 std::vector<Eigen::Vector3f> &points) = 0;
 
-  protected:
+protected:
     GLuint vertex_position_;
     GLuint vertex_position_buffer_;
     GLuint MVP_;
 };
 
 class SimpleBlackShaderForPointCloudNormal : public SimpleBlackShader {
-  public:
+public:
     SimpleBlackShaderForPointCloudNormal()
         : SimpleBlackShader("SimpleBlackShaderForPointCloudNormal") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;
@@ -85,11 +85,11 @@ class SimpleBlackShaderForPointCloudNormal : public SimpleBlackShader {
 };
 
 class SimpleBlackShaderForTriangleMeshWireFrame : public SimpleBlackShader {
-  public:
+public:
     SimpleBlackShaderForTriangleMeshWireFrame()
         : SimpleBlackShader("SimpleBlackShaderForTriangleMeshWireFrame") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;

--- a/src/Visualization/Shader/SimpleShader.h
+++ b/src/Visualization/Shader/SimpleShader.h
@@ -35,13 +35,13 @@ namespace open3d {
 namespace glsl {
 
 class SimpleShader : public ShaderWrapper {
-  public:
+public:
     ~SimpleShader() override { Release(); }
 
-  protected:
+protected:
     SimpleShader(const std::string &name) : ShaderWrapper(name) { Compile(); }
 
-  protected:
+protected:
     bool Compile() final;
     void Release() final;
     bool BindGeometry(const Geometry &geometry,
@@ -52,7 +52,7 @@ class SimpleShader : public ShaderWrapper {
                         const ViewControl &view) final;
     void UnbindGeometry() final;
 
-  protected:
+protected:
     virtual bool PrepareRendering(const Geometry &geometry,
                                   const RenderOption &option,
                                   const ViewControl &view) = 0;
@@ -62,7 +62,7 @@ class SimpleShader : public ShaderWrapper {
                                 std::vector<Eigen::Vector3f> &points,
                                 std::vector<Eigen::Vector3f> &colors) = 0;
 
-  protected:
+protected:
     GLuint vertex_position_;
     GLuint vertex_position_buffer_;
     GLuint vertex_color_;
@@ -71,10 +71,10 @@ class SimpleShader : public ShaderWrapper {
 };
 
 class SimpleShaderForPointCloud : public SimpleShader {
-  public:
+public:
     SimpleShaderForPointCloud() : SimpleShader("SimpleShaderForPointCloud") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;
@@ -86,10 +86,10 @@ class SimpleShaderForPointCloud : public SimpleShader {
 };
 
 class SimpleShaderForLineSet : public SimpleShader {
-  public:
+public:
     SimpleShaderForLineSet() : SimpleShader("SimpleShaderForLineSet") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;
@@ -101,11 +101,11 @@ class SimpleShaderForLineSet : public SimpleShader {
 };
 
 class SimpleShaderForTriangleMesh : public SimpleShader {
-  public:
+public:
     SimpleShaderForTriangleMesh()
         : SimpleShader("SimpleShaderForTriangleMesh") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;
@@ -117,10 +117,10 @@ class SimpleShaderForTriangleMesh : public SimpleShader {
 };
 
 class SimpleShaderForVoxelGrid : public SimpleShader {
-  public:
+public:
     SimpleShaderForVoxelGrid() : SimpleShader("SimpleShaderForVoxelGrid") {}
 
-  protected:
+protected:
     bool PrepareRendering(const Geometry &geometry,
                           const RenderOption &option,
                           const ViewControl &view) final;

--- a/src/Visualization/Utility/BoundingBox.h
+++ b/src/Visualization/Utility/BoundingBox.h
@@ -34,16 +34,16 @@ namespace open3d {
 /// A 3D bounding box class
 /// It is a utility class for Visualization
 class BoundingBox {
-  public:
+public:
     BoundingBox();
     BoundingBox(const Geometry3D &geometry);
     ~BoundingBox();
 
-  public:
+public:
     void Reset();
     void FitInGeometry(const Geometry3D &geometry);
 
-  public:
+public:
     Eigen::Vector3d GetCenter() const {
         return (min_bound_ + max_bound_) * 0.5;
     }
@@ -71,7 +71,7 @@ class BoundingBox {
         return std::string(buffer);
     }
 
-  public:
+public:
     Eigen::Vector3d min_bound_ = Eigen::Vector3d::Zero();
     Eigen::Vector3d max_bound_ = Eigen::Vector3d::Zero();
 };

--- a/src/Visualization/Utility/ColorMap.cpp
+++ b/src/Visualization/Utility/ColorMap.cpp
@@ -33,7 +33,7 @@ namespace open3d {
 namespace {
 
 class GlobalColorMapSingleton {
-  private:
+private:
     GlobalColorMapSingleton() : color_map_(new ColorMapJet) {
         PrintDebug("Global colormap init.\n");
     }
@@ -41,16 +41,16 @@ class GlobalColorMapSingleton {
     GlobalColorMapSingleton &operator=(const GlobalColorMapSingleton &) =
             delete;
 
-  public:
+public:
     ~GlobalColorMapSingleton() { PrintDebug("Global colormap destruct.\n"); }
 
-  public:
+public:
     static GlobalColorMapSingleton &GetInstance() {
         static GlobalColorMapSingleton singleton;
         return singleton;
     }
 
-  public:
+public:
     std::shared_ptr<const ColorMap> color_map_;
 };
 

--- a/src/Visualization/Utility/ColorMap.h
+++ b/src/Visualization/Utility/ColorMap.h
@@ -31,7 +31,7 @@
 namespace open3d {
 
 class ColorMap {
-  public:
+public:
     enum class ColorMapOption {
         Gray = 0,
         Jet = 1,
@@ -40,15 +40,15 @@ class ColorMap {
         Hot = 4,
     };
 
-  public:
+public:
     ColorMap(){};
     virtual ~ColorMap(){};
 
-  public:
+public:
     /// Function to get a color from a value in [0..1]
     virtual Eigen::Vector3d GetColor(double value) const = 0;
 
-  protected:
+protected:
     double Interpolate(
             double value, double y0, double x0, double y1, double x1) const {
         if (value < x0) return y0;
@@ -67,16 +67,16 @@ class ColorMap {
 };
 
 class ColorMapGray final : public ColorMap {
-  public:
+public:
     Eigen::Vector3d GetColor(double value) const final;
 };
 
 /// See Matlab's Jet colormap
 class ColorMapJet final : public ColorMap {
-  public:
+public:
     Eigen::Vector3d GetColor(double value) const final;
 
-  protected:
+protected:
     double JetBase(double value) const {
         if (value <= -0.75) {
             return 0.0;
@@ -94,18 +94,18 @@ class ColorMapJet final : public ColorMap {
 
 /// See Matlab's Summer colormap
 class ColorMapSummer final : public ColorMap {
-  public:
+public:
     Eigen::Vector3d GetColor(double value) const final;
 };
 
 /// See Matlab's Winter colormap
 class ColorMapWinter final : public ColorMap {
-  public:
+public:
     Eigen::Vector3d GetColor(double value) const final;
 };
 
 class ColorMapHot final : public ColorMap {
-  public:
+public:
     Eigen::Vector3d GetColor(double value) const final;
 };
 

--- a/src/Visualization/Utility/PointCloudPicker.h
+++ b/src/Visualization/Utility/PointCloudPicker.h
@@ -37,11 +37,11 @@ class PointCloud;
 
 /// A utility class to store picked points of a pointcloud
 class PointCloudPicker : public Geometry3D {
-  public:
+public:
     PointCloudPicker() : Geometry3D(Geometry::GeometryType::Unspecified) {}
     ~PointCloudPicker() override {}
 
-  public:
+public:
     void Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const final;
@@ -49,7 +49,7 @@ class PointCloudPicker : public Geometry3D {
     void Transform(const Eigen::Matrix4d& transformation) override;
     bool SetPointCloud(std::shared_ptr<const Geometry> ptr);
 
-  public:
+public:
     std::shared_ptr<const Geometry> pointcloud_ptr_;
     std::vector<size_t> picked_indices_;
 };

--- a/src/Visualization/Utility/SelectionPolygon.h
+++ b/src/Visualization/Utility/SelectionPolygon.h
@@ -44,18 +44,18 @@ class SelectionPolygonVolume;
 /// The coordinates in SelectionPolygon are lower-left corner based (the OpenGL
 /// convention).
 class SelectionPolygon : public Geometry2D {
-  public:
+public:
     enum class SectionPolygonType {
         Unfilled = 0,
         Rectangle = 1,
         Polygon = 2,
     };
 
-  public:
+public:
     SelectionPolygon() : Geometry2D(Geometry::GeometryType::Unspecified) {}
     ~SelectionPolygon() override {}
 
-  public:
+public:
     void Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector2d GetMinBound() const final;
@@ -68,7 +68,7 @@ class SelectionPolygon : public Geometry2D {
     std::shared_ptr<SelectionPolygonVolume> CreateSelectionPolygonVolume(
             const ViewControl &view);
 
-  private:
+private:
     std::shared_ptr<PointCloud> CropPointCloudInRectangle(
             const PointCloud &input, const ViewControl &view);
     std::shared_ptr<PointCloud> CropPointCloudInPolygon(
@@ -82,7 +82,7 @@ class SelectionPolygon : public Geometry2D {
     std::vector<size_t> CropInPolygon(const std::vector<Eigen::Vector3d> &input,
                                       const ViewControl &view);
 
-  public:
+public:
     std::vector<Eigen::Vector2d> polygon_;
     bool is_closed_ = false;
     Image polygon_interior_mask_;

--- a/src/Visualization/Utility/SelectionPolygonVolume.h
+++ b/src/Visualization/Utility/SelectionPolygonVolume.h
@@ -39,17 +39,17 @@ class PointCloud;
 class TriangleMesh;
 
 class SelectionPolygonVolume : public IJsonConvertible {
-  public:
+public:
     ~SelectionPolygonVolume() override {}
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
     std::shared_ptr<PointCloud> CropPointCloud(const PointCloud &input) const;
     std::shared_ptr<TriangleMesh> CropTriangleMesh(
             const TriangleMesh &input) const;
 
-  private:
+private:
     std::shared_ptr<PointCloud> CropPointCloudInPolygon(
             const PointCloud &input) const;
     std::shared_ptr<TriangleMesh> CropTriangleMeshInPolygon(
@@ -57,7 +57,7 @@ class SelectionPolygonVolume : public IJsonConvertible {
     std::vector<size_t> CropInPolygon(
             const std::vector<Eigen::Vector3d> &input) const;
 
-  public:
+public:
     std::string orthogonal_axis_ = "";
     std::vector<Eigen::Vector3d> bounding_polygon_;
     double axis_min_ = 0.0;

--- a/src/Visualization/Visualizer/RenderOption.h
+++ b/src/Visualization/Visualizer/RenderOption.h
@@ -33,7 +33,7 @@
 namespace open3d {
 
 class RenderOption : public IJsonConvertible {
-  public:
+public:
     // Global options
     enum class TextureInterpolationOption {
         Nearest = 0,
@@ -81,7 +81,7 @@ class RenderOption : public IJsonConvertible {
         StretchWithWindow = 2,
     };
 
-  public:
+public:
     RenderOption() {
         // VS2013 does not fully support C++11
         // Array initialization has to be done in constructors.
@@ -108,11 +108,11 @@ class RenderOption : public IJsonConvertible {
     }
     ~RenderOption() override {}
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     void ToggleLightOn() { light_on_ = !light_on_; }
     void ToggleInterpolationOption() {
         if (interpolation_option_ == TextureInterpolationOption::Nearest) {
@@ -156,7 +156,7 @@ class RenderOption : public IJsonConvertible {
         }
     }
 
-  public:
+public:
     // global options
     Eigen::Vector3d background_color_ = Eigen::Vector3d::Ones();
     TextureInterpolationOption interpolation_option_ =

--- a/src/Visualization/Visualizer/RenderOptionWithEditing.h
+++ b/src/Visualization/Visualizer/RenderOptionWithEditing.h
@@ -33,16 +33,16 @@
 namespace open3d {
 
 class RenderOptionWithEditing : public RenderOption {
-  public:
+public:
     static const double PICKER_SPHERE_SIZE_MIN;
     static const double PICKER_SPHERE_SIZE_MAX;
     static const double PICKER_SPHERE_SIZE_DEFAULT;
 
-  public:
+public:
     RenderOptionWithEditing() {}
     ~RenderOptionWithEditing() override {}
 
-  public:
+public:
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
     void IncreaseSphereSize() {
@@ -54,7 +54,7 @@ class RenderOptionWithEditing : public RenderOption {
                 pointcloud_picker_sphere_size_ * 0.5, PICKER_SPHERE_SIZE_MIN);
     }
 
-  public:
+public:
     // Selection polygon
     Eigen::Vector3d selection_polygon_boundary_color_ =
             Eigen::Vector3d(0.3, 0.3, 0.3);

--- a/src/Visualization/Visualizer/ViewControl.h
+++ b/src/Visualization/Visualizer/ViewControl.h
@@ -35,7 +35,7 @@
 namespace open3d {
 
 class ViewControl {
-  public:
+public:
     static const double FIELD_OF_VIEW_MAX;
     static const double FIELD_OF_VIEW_MIN;
     static const double FIELD_OF_VIEW_DEFAULT;
@@ -53,7 +53,7 @@ class ViewControl {
         Orthogonal = 1,
     };
 
-  public:
+public:
     /// Function to set view points
     /// This function obtains OpenGL context and calls OpenGL functions to set
     /// the view point.
@@ -133,7 +133,7 @@ class ViewControl {
     double GetZNear() const { return z_near_; }
     double GetZFar() const { return z_far_; }
 
-  protected:
+protected:
     int window_width_ = 0;
     int window_height_ = 0;
     BoundingBox bounding_box_;

--- a/src/Visualization/Visualizer/ViewControlWithCustomAnimation.h
+++ b/src/Visualization/Visualizer/ViewControlWithCustomAnimation.h
@@ -33,14 +33,14 @@
 namespace open3d {
 
 class ViewControlWithCustomAnimation : public ViewControl {
-  public:
+public:
     enum AnimationMode {
         FreeMode = 0,
         PreviewMode = 1,
         PlayMode = 2,
     };
 
-  public:
+public:
     void Reset() override;
     void ChangeFieldOfView(double step) override;
     void Scale(double scale) override;
@@ -85,7 +85,7 @@ class ViewControlWithCustomAnimation : public ViewControl {
     }
     bool IsValidPinholeCameraTrajectory() const;
 
-  protected:
+protected:
     size_t CurrentFrame() const { return (size_t)round(current_frame_); }
     size_t CurrentKeyframe() const { return (size_t)round(current_keyframe_); }
     double RegularizeFrameIndex(double current_frame,
@@ -93,7 +93,7 @@ class ViewControlWithCustomAnimation : public ViewControl {
                                 bool is_loop);
     void SetViewControlFromTrajectory();
 
-  protected:
+protected:
     AnimationMode animation_mode_ = AnimationMode::FreeMode;
     ViewTrajectory view_trajectory_;
     double current_frame_ = 0.0;

--- a/src/Visualization/Visualizer/ViewControlWithEditing.h
+++ b/src/Visualization/Visualizer/ViewControlWithEditing.h
@@ -31,7 +31,7 @@
 namespace open3d {
 
 class ViewControlWithEditing : public ViewControl {
-  public:
+public:
     enum EditingMode {
         FreeMode = 0,
         OrthoPositiveX = 1,
@@ -42,7 +42,7 @@ class ViewControlWithEditing : public ViewControl {
         OrthoNegativeZ = 6,
     };
 
-  public:
+public:
     void Reset() override;
     void ChangeFieldOfView(double step) override;
     void Scale(double scale) override;
@@ -80,7 +80,7 @@ class ViewControlWithEditing : public ViewControl {
     void ToggleLocking() { is_view_locked_ = !is_view_locked_; }
     bool IsLocked() const { return is_view_locked_; }
 
-  protected:
+protected:
     EditingMode editing_mode_ = FreeMode;
     ViewParameters view_status_backup_;
     bool is_view_locked_ = false;

--- a/src/Visualization/Visualizer/ViewParameters.h
+++ b/src/Visualization/Visualizer/ViewParameters.h
@@ -33,22 +33,22 @@
 namespace open3d {
 
 class ViewParameters : public IJsonConvertible {
-  public:
+public:
     typedef Eigen::Matrix<double, 17, 4, Eigen::RowMajor> Matrix17x4d;
     typedef Eigen::Matrix<double, 17, 1> Vector17d;
     typedef Eigen::aligned_allocator<Matrix17x4d> Matrix17x4d_allocator;
 
-  public:
+public:
     ViewParameters() {}
     ~ViewParameters() override {}
 
-  public:
+public:
     Vector17d ConvertToVector17d();
     void ConvertFromVector17d(const Vector17d &v);
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     double field_of_view_;
     double zoom_;
     Eigen::Vector3d lookat_;

--- a/src/Visualization/Visualizer/ViewTrajectory.h
+++ b/src/Visualization/Visualizer/ViewTrajectory.h
@@ -35,17 +35,17 @@
 namespace open3d {
 
 class ViewTrajectory : public IJsonConvertible {
-  public:
+public:
     static const int INTERVAL_MAX;
     static const int INTERVAL_MIN;
     static const int INTERVAL_STEP;
     static const int INTERVAL_DEFAULT;
 
-  public:
+public:
     ViewTrajectory() {}
     ~ViewTrajectory() override {}
 
-  public:
+public:
     /// Function to compute a Cubic Spline Interpolation
     /// See this paper for details:
     /// Bartels, R. H.; Beatty, J. C.; and Barsky, B. A. "Hermite and Cubic
@@ -83,7 +83,7 @@ class ViewTrajectory : public IJsonConvertible {
     bool ConvertToJsonValue(Json::Value &value) const override;
     bool ConvertFromJsonValue(const Json::Value &value) override;
 
-  public:
+public:
     std::vector<ViewParameters> view_status_;
     bool is_loop_ = false;
     int interval_ = INTERVAL_DEFAULT;

--- a/src/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Visualization/Visualizer/Visualizer.cpp
@@ -33,19 +33,19 @@ namespace open3d {
 namespace {
 
 class GLFWEnvironmentSingleton {
-  private:
+private:
     GLFWEnvironmentSingleton() { PrintDebug("GLFW init.\n"); }
     GLFWEnvironmentSingleton(const GLFWEnvironmentSingleton &) = delete;
     GLFWEnvironmentSingleton &operator=(const GLFWEnvironmentSingleton &) =
             delete;
 
-  public:
+public:
     ~GLFWEnvironmentSingleton() {
         glfwTerminate();
         PrintDebug("GLFW destruct.\n");
     }
 
-  public:
+public:
     static GLFWEnvironmentSingleton &GetInstance() {
         static GLFWEnvironmentSingleton singleton;
         return singleton;

--- a/src/Visualization/Visualizer/Visualizer.h
+++ b/src/Visualization/Visualizer/Visualizer.h
@@ -45,9 +45,9 @@ class TriangleMesh;
 class Image;
 
 class Visualizer {
-  public:
+public:
     struct MouseControl {
-      public:
+    public:
         bool is_mouse_left_button_down = false;
         bool is_mouse_middle_button_down = false;
         bool is_control_key_down = false;
@@ -58,14 +58,14 @@ class Visualizer {
         double mouse_position_y = 0.0;
     };
 
-  public:
+public:
     Visualizer();
     virtual ~Visualizer();
     Visualizer(Visualizer &&) = delete;
     Visualizer(const Visualizer &) = delete;
     Visualizer &operator=(const Visualizer &) = delete;
 
-  public:
+public:
     /// Function to create a window and initialize GLFW
     /// This function MUST be called from the main thread.
     bool CreateVisualizerWindow(const std::string &window_name = "Open3D",
@@ -143,7 +143,7 @@ class Visualizer {
 
     const std::string &GetWindowName() const { return window_name_; }
 
-  protected:
+protected:
     /// Function to initialize OpenGL
     virtual bool InitOpenGL();
 
@@ -175,7 +175,7 @@ class Visualizer {
             GLFWwindow *window, int key, int scancode, int action, int mods);
     virtual void WindowCloseCallback(GLFWwindow *window);
 
-  protected:
+protected:
     // window
     GLFWwindow *window_ = NULL;
     std::string window_name_ = "Open3D";

--- a/src/Visualization/Visualizer/VisualizerWithCustomAnimation.h
+++ b/src/Visualization/Visualizer/VisualizerWithCustomAnimation.h
@@ -31,7 +31,7 @@
 namespace open3d {
 
 class VisualizerWithCustomAnimation : public Visualizer {
-  public:
+public:
     VisualizerWithCustomAnimation();
     ~VisualizerWithCustomAnimation() override;
     VisualizerWithCustomAnimation(const VisualizerWithCustomAnimation &) =
@@ -39,7 +39,7 @@ class VisualizerWithCustomAnimation : public Visualizer {
     VisualizerWithCustomAnimation &operator=(
             const VisualizerWithCustomAnimation &) = delete;
 
-  public:
+public:
     void PrintVisualizerHelp() override;
     void UpdateWindowTitle() override;
     void Play(bool recording = false,
@@ -60,7 +60,7 @@ class VisualizerWithCustomAnimation : public Visualizer {
         recording_depth_trajectory_filename_ = trajectory;
     }
 
-  protected:
+protected:
     bool InitViewControl() override;
     void MouseMoveCallback(GLFWwindow *window, double x, double y) override;
     void MouseScrollCallback(GLFWwindow *window, double x, double y) override;
@@ -74,7 +74,7 @@ class VisualizerWithCustomAnimation : public Visualizer {
                           int action,
                           int mods) override;
 
-  protected:
+protected:
     std::string recording_image_basedir_ = "image/";
     std::string recording_image_filename_format_ = "image_%06d.png";
     std::string recording_image_trajectory_filename_ = "image_trajectory.json";

--- a/src/Visualization/Visualizer/VisualizerWithEditing.h
+++ b/src/Visualization/Visualizer/VisualizerWithEditing.h
@@ -34,14 +34,14 @@ class SelectionPolygon;
 class PointCloudPicker;
 
 class VisualizerWithEditing : public Visualizer {
-  public:
+public:
     enum class SelectionMode {
         None = 0,
         Rectangle = 1,
         Polygon = 2,
     };
 
-  public:
+public:
     VisualizerWithEditing(double voxel_size = -1.0,
                           bool use_dialog = true,
                           const std::string &directory = "")
@@ -52,7 +52,7 @@ class VisualizerWithEditing : public Visualizer {
     VisualizerWithEditing(const VisualizerWithEditing &) = delete;
     VisualizerWithEditing &operator=(const VisualizerWithEditing &) = delete;
 
-  public:
+public:
     bool AddGeometry(std::shared_ptr<const Geometry> geometry_ptr) override;
     void PrintVisualizerHelp() override;
     void UpdateWindowTitle() override;
@@ -60,7 +60,7 @@ class VisualizerWithEditing : public Visualizer {
     int PickPoint(double x, double y);
     std::vector<size_t> &GetPickedPoints();
 
-  protected:
+protected:
     bool InitViewControl() override;
     bool InitRenderOption() override;
     void WindowResizeCallback(GLFWwindow *window, int w, int h) override;
@@ -79,7 +79,7 @@ class VisualizerWithEditing : public Visualizer {
     void InvalidatePicking();
     void SaveCroppingResult(const std::string &filename = "");
 
-  protected:
+protected:
     std::shared_ptr<SelectionPolygon> selection_polygon_ptr_;
     std::shared_ptr<glsl::SelectionPolygonRenderer>
             selection_polygon_renderer_ptr_;

--- a/src/Visualization/Visualizer/VisualizerWithKeyCallback.h
+++ b/src/Visualization/Visualizer/VisualizerWithKeyCallback.h
@@ -32,22 +32,22 @@
 namespace open3d {
 
 class VisualizerWithKeyCallback : public Visualizer {
-  public:
+public:
     typedef std::pair<int, std::function<bool(Visualizer *)>> KeyCallbackPair;
 
-  public:
+public:
     VisualizerWithKeyCallback();
     ~VisualizerWithKeyCallback() override;
     VisualizerWithKeyCallback(const VisualizerWithKeyCallback &) = delete;
     VisualizerWithKeyCallback &operator=(const VisualizerWithKeyCallback &) =
             delete;
 
-  public:
+public:
     void PrintVisualizerHelp() override;
     void RegisterKeyCallback(int key,
                              std::function<bool(Visualizer *)> callback);
 
-  protected:
+protected:
     void KeyPressCallback(GLFWwindow *window,
                           int key,
                           int scancode,
@@ -55,7 +55,7 @@ class VisualizerWithKeyCallback : public Visualizer {
                           int mods) override;
     std::string PrintKeyToString(int key);
 
-  protected:
+protected:
     std::map<int, std::function<bool(Visualizer *)>> key_to_callback_;
 };
 


### PR DESCRIPTION
Quick follow up for #777. Google indents `public` by 1 and everything else by 2. But we indent everything else by 4, making half-indenting `public` look strange. This PR disables indentation for class access modifiers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/793)
<!-- Reviewable:end -->
