### PR TITLE
fixed parameters for depth in Kinect2

### DIFF
--- a/src/Core/Camera/PinholeCameraIntrinsic.cpp
+++ b/src/Core/Camera/PinholeCameraIntrinsic.cpp
@@ -46,7 +46,7 @@ PinholeCameraIntrinsic::PinholeCameraIntrinsic(
         SetIntrinsics(640, 480, 525.0, 525.0, 319.5, 239.5);
     else if (param ==
              PinholeCameraIntrinsicParameters::Kinect2DepthCameraDefault)
-        SetIntrinsics(512, 424, 254.878, 205.395, 365.456, 365.456);
+        SetIntrinsics(512, 424, 365.456, 365.456, 254.878, 205.395);
     else if (param ==
              PinholeCameraIntrinsicParameters::Kinect2ColorCameraDefault)
         SetIntrinsics(1920, 1080, 1059.9718, 1059.9718, 975.7193, 545.9533);


### PR DESCRIPTION
cx and cy was replaced with fx, fy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/801)
<!-- Reviewable:end -->
