### PR TITLE
Fix Colomap segfault and divergence issues

### DIFF
--- a/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
+++ b/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
@@ -94,7 +94,7 @@ void ColorMapOptimizationJacobian::ComputeJacobianAndResidualNonRigid(
     pattern.setZero();
     r = 0;
     int anchor_w = warping_fields.anchor_w_;
-    int anchor_step = warping_fields.anchor_step_;
+    double anchor_step = warping_fields.anchor_step_;
     int vid = visiblity_image_to_vertex[row];
     Eigen::Vector3d V = mesh.vertices_[vid];
     Eigen::Vector4d G = extrinsic * Eigen::Vector4d(V(0), V(1), V(2), 1);

--- a/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
+++ b/src/Core/ColorMap/ColorMapOptimizationJacobian.cpp
@@ -106,6 +106,10 @@ void ColorMapOptimizationJacobian::ComputeJacobianAndResidualNonRigid(
     }
     int ii = (int)(u / anchor_step);
     int jj = (int)(v / anchor_step);
+    if (ii >= warping_fields.anchor_w_ - 1 ||
+        jj >= warping_fields.anchor_h_ - 1) {
+        return;
+    }
     double p = (u - ii * anchor_step) / anchor_step;
     double q = (v - jj * anchor_step) / anchor_step;
     Eigen::Vector2d grids[4] = {

--- a/src/Core/ColorMap/ImageWarpingField.cpp
+++ b/src/Core/ColorMap/ImageWarpingField.cpp
@@ -57,7 +57,7 @@ void ImageWarpingField::InitializeWarpingFields(
 Eigen::Vector2d ImageWarpingField::QueryFlow(int i, int j) const {
     int baseidx = (i + j * anchor_w_) * 2;
     // exceptional case: quried anchor index is out of pre-defined space
-    if (baseidx < 0 || baseidx > anchor_w_ * anchor_h_ * 2)
+    if (baseidx < 0 || baseidx >= anchor_w_ * anchor_h_ * 2)
         return Eigen::Vector2d(0.0, 0.0);
     else
         return Eigen::Vector2d(flow_(baseidx), flow_(baseidx + 1));

--- a/src/Core/ColorMap/TriangleMeshAndImageUtilities.cpp
+++ b/src/Core/ColorMap/TriangleMeshAndImageUtilities.cpp
@@ -78,7 +78,7 @@ CreateVertexAndImageVisibility(
                 continue;
             float d_sensor = *PointerAt<float>(*images_depth[c], u_d, v_d);
             if (d_sensor > maximum_allowable_depth) continue;
-            if (*PointerAt<unsigned char>(*images_depth[c], u_d, v_d) == 255)
+            if (*PointerAt<unsigned char>(*images_mask[c], u_d, v_d) == 255)
                 continue;
             if (std::fabs(d - d_sensor) < depth_threshold_for_visiblity_check) {
 #ifdef _OPENMP


### PR DESCRIPTION
Several changes:
1. When computing visibility map `images_mask` is now used, previously it was ignored due to a typo.
2. Index out-of-bound segfaults I: `baseidx < anchor_w_ * anchor_h_ * 2`, cannot be `=`
3. Index out-of-bound segfaults II: Given a pixel location, the base anchor point index `(ii, jj)` must satisfy
    ```cpp
    ii < anchor_w_ - 1;
    jj < anchor_h_ - 1;
    ```
    This is because if the base location is `(ii, jj)`, the four anchors are 
    ```cpp
    (ii, jj), (ii + 1, jj), (ii, jj + 1), (ii + 1, jj + 1)
    ```
    and we must have
    ```cpp
    ii + 1 < anchor_w_;
    jj + 1 < anchor_h_;
    ```
4. Divergence: `double anchor_step` shall be used instead of `int anchor_step`, this creates small misalignments when getting pixel values from the image, leading to divergence in the end.

Compared numerical results (`Residual error` and `reg`) for non-rigid optimization against code base before https://github.com/IntelVCL/Open3D/pull/717, and veified that they are identical.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/819)
<!-- Reviewable:end -->
