### PR TITLE
Standardize API of SolveLinearSystemPSD

### DIFF
--- a/src/Core/ColorMap/ColorMapOptimization.cpp
+++ b/src/Core/ColorMap/ColorMapOptimization.cpp
@@ -112,7 +112,8 @@ void OptimizeImageCoorNonrigid(
             bool success;
             Eigen::VectorXd result;
             std::tie(success, result) =
-                    SolveLinearSystem(JTJ, -JTr, false, true);
+                    SolveLinearSystem(JTJ, -JTr, /*prefer_sparse=*/true,
+                                      /*check_det=*/false, /*check_psd=*/false);
             Eigen::Vector6d result_pose;
             result_pose << result.block(0, 0, 6, 1);
             auto delta = TransformVector6dToMatrix4d(result_pose);

--- a/src/Core/ColorMap/ColorMapOptimization.cpp
+++ b/src/Core/ColorMap/ColorMapOptimization.cpp
@@ -112,7 +112,7 @@ void OptimizeImageCoorNonrigid(
             bool success;
             Eigen::VectorXd result;
             std::tie(success, result) =
-                    SolveLinearSystem(JTJ, -JTr, /*prefer_sparse=*/true,
+                    SolveLinearSystem(JTJ, -JTr, /*prefer_sparse=*/false,
                                       /*check_det=*/false, /*check_psd=*/false);
             Eigen::Vector6d result_pose;
             result_pose << result.block(0, 0, 6, 1);

--- a/src/Core/ColorMap/ColorMapOptimization.cpp
+++ b/src/Core/ColorMap/ColorMapOptimization.cpp
@@ -111,7 +111,8 @@ void OptimizeImageCoorNonrigid(
 
             bool success;
             Eigen::VectorXd result;
-            std::tie(success, result) = SolveLinearSystem(JTJ, -JTr, false);
+            std::tie(success, result) =
+                    SolveLinearSystem(JTJ, -JTr, false, true);
             Eigen::Vector6d result_pose;
             result_pose << result.block(0, 0, 6, 1);
             auto delta = TransformVector6dToMatrix4d(result_pose);

--- a/src/Core/ColorMap/ColorMapOptimization.cpp
+++ b/src/Core/ColorMap/ColorMapOptimization.cpp
@@ -111,9 +111,9 @@ void OptimizeImageCoorNonrigid(
 
             bool success;
             Eigen::VectorXd result;
-            std::tie(success, result) =
-                    SolveLinearSystem(JTJ, -JTr, /*prefer_sparse=*/false,
-                                      /*check_det=*/false, /*check_psd=*/false);
+            std::tie(success, result) = SolveLinearSystemPSD(
+                    JTJ, -JTr, /*prefer_sparse=*/false,
+                    /*check_det=*/false, /*check_psd=*/false);
             Eigen::Vector6d result_pose;
             result_pose << result.block(0, 0, 6, 1);
             auto delta = TransformVector6dToMatrix4d(result_pose);

--- a/src/Core/Registration/ColoredICP.cpp
+++ b/src/Core/Registration/ColoredICP.cpp
@@ -129,7 +129,7 @@ std::shared_ptr<PointCloudForColoredICP> InitializePointCloudForColoredICP(
             bool is_success;
             Eigen::MatrixXd x;
             std::tie(is_success, x) =
-                    SolveLinearSystem(A.transpose() * A, A.transpose() * b);
+                    SolveLinearSystemPSD(A.transpose() * A, A.transpose() * b);
             if (is_success) {
                 output->color_gradient_[k] = x;
             }

--- a/src/Core/Registration/FastGlobalRegistration.cpp
+++ b/src/Core/Registration/FastGlobalRegistration.cpp
@@ -299,7 +299,7 @@ Eigen::Matrix4d OptimizePairwiseRegistration(
         }
         bool success;
         Eigen::VectorXd result;
-        std::tie(success, result) = SolveLinearSystem(-JTJ, JTr);
+        std::tie(success, result) = SolveLinearSystemPSD(-JTJ, JTr);
         Eigen::Matrix4d delta = TransformVector6dToMatrix4d(result);
         trans = delta * trans;
         point_cloud_copy_j.Transform(delta);

--- a/src/Core/Registration/GlobalOptimization.cpp
+++ b/src/Core/Registration/GlobalOptimization.cpp
@@ -605,8 +605,9 @@ void GlobalOptimizationLevenbergMarquardt::OptimizePoseGraph(
             bool solver_success = false;
 
             // Solve H_LM @ delta == b using a sparse solver
-            std::tie(solver_success, delta) = SolveLinearSystem(
-                    H_LM, b, /*check_det=*/false, /*prefer_sparse=*/true);
+            std::tie(solver_success, delta) =
+                    SolveLinearSystem(H_LM, b, /*prefer_sparse=*/true,
+                                      /*check_det=*/false, /*check_psd=*/false);
 
             stop = stop || CheckRelativeIncrement(delta, x, criteria);
             if (!stop) {

--- a/src/Core/Registration/GlobalOptimization.cpp
+++ b/src/Core/Registration/GlobalOptimization.cpp
@@ -605,9 +605,9 @@ void GlobalOptimizationLevenbergMarquardt::OptimizePoseGraph(
             bool solver_success = false;
 
             // Solve H_LM @ delta == b using a sparse solver
-            std::tie(solver_success, delta) =
-                    SolveLinearSystem(H_LM, b, /*prefer_sparse=*/true,
-                                      /*check_det=*/false, /*check_psd=*/false);
+            std::tie(solver_success, delta) = SolveLinearSystemPSD(
+                    H_LM, b, /*prefer_sparse=*/true,
+                    /*check_det=*/false, /*check_psd=*/false);
 
             stop = stop || CheckRelativeIncrement(delta, x, criteria);
             if (!stop) {

--- a/src/Core/Registration/GlobalOptimization.cpp
+++ b/src/Core/Registration/GlobalOptimization.cpp
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
 #include "GlobalOptimization.h"
+#include "Eigen.h"
 
 #include <vector>
 #include <tuple>
@@ -601,26 +602,11 @@ void GlobalOptimizationLevenbergMarquardt::OptimizePoseGraph(
         do {
             Eigen::MatrixXd H_LM = H + current_lambda * H_I;
             Eigen::VectorXd delta(H_LM.cols());
+            bool solver_success = false;
 
-            // Using a sparse solver
-            Eigen::SparseMatrix<double> H_LM_sparse = H_LM.sparseView();
-            Eigen::SimplicialCholesky<Eigen::SparseMatrix<double>> chol;
-            chol.compute(H_LM_sparse);
-
-            if (chol.info() == Eigen::Success) {
-                delta = chol.solve(b);
-                if (chol.info() != Eigen::Success) {
-                    PrintInfo(
-                            "[GlobalOptimizationLM] sparse solver couldn't "
-                            "solve !! switching to dense solver");
-                    delta = H_LM.ldlt().solve(b);
-                }
-            } else {
-                PrintInfo(
-                        "[GlobalOptimizationLM] Cholesky Decomposition Failed "
-                        "!! switching to dense solver");
-                delta = H_LM.ldlt().solve(b);
-            }
+            // Solve H_LM @ delta == b using a sparse solver
+            std::tie(solver_success, delta) = SolveLinearSystem(
+                    H_LM, b, /*check_det=*/false, /*prefer_sparse=*/true);
 
             stop = stop || CheckRelativeIncrement(delta, x, criteria);
             if (!stop) {

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -59,6 +59,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
 
     if (prefer_sparse) {
         Eigen::SparseMatrix<double> A_sparse = A.sparseView();
+        // TODO: avoid deprecated API SimplicialCholesky
         Eigen::SimplicialCholesky<Eigen::SparseMatrix<double>> A_chol;
         A_chol.compute(A_sparse);
         if (A_chol.info() == Eigen::Success) {

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -42,6 +42,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
     if (check_det) {
         double det = A.determinant();
         if (fabs(det) < 1e-6 || std::isnan(det) || std::isinf(det)) {
+            PrintInfo("check_det failed, empty vector will be returned\n");
             return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
         }
     }
@@ -51,6 +52,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
         Eigen::LLT<Eigen::MatrixXd> A_llt(A);
         if (!A.isApprox(A.transpose()) ||
             A_llt.info() == Eigen::NumericalIssue) {
+            PrintInfo("check_psd failed, empty vector will be returned\n");
             return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
         }
     }

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -48,7 +48,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
 
     if (check_psd) {
         Eigen::LLT<Eigen::MatrixXd> A_llt(A);
-        if (A_llt.info() == Eigen::NumericalIssue) {
+        if (A.transpose() != A || A_llt.info() == Eigen::NumericalIssue) {
             return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
         }
     }

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -57,12 +57,12 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
             } else {
                 PrintInfo(
                         "[SolveLinearSystem] sparse solver couldn't "
-                        "solve !! switching to dense solver");
+                        "solve !! switching to dense solver\n");
             }
         } else {
             PrintInfo(
-                    "[GlobalOptimizationLM] Cholesky Decomposition Failed "
-                    "!! switching to dense solver");
+                    "[SolveLinearSystem] Cholesky Decomposition Failed "
+                    "!! switching to dense solver\n");
         }
     }
 

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -48,7 +48,8 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
 
     if (check_psd) {
         Eigen::LLT<Eigen::MatrixXd> A_llt(A);
-        if (A.transpose() != A || A_llt.info() == Eigen::NumericalIssue) {
+        if (!A.isApprox(A.transpose()) ||
+            A_llt.info() == Eigen::NumericalIssue) {
             return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
         }
     }

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -62,9 +62,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
         A_chol.compute(A_sparse);
         if (A_chol.info() == Eigen::Success) {
             x = A_chol.solve(b);
-            if (A_chol.info() == Eigen::Success) {
-                return std::make_tuple(true, std::move(x));
-            } else {
+            if (A_chol.info() != Eigen::Success) {
                 PrintInfo(
                         "[SolveLinearSystem] sparse solver couldn't "
                         "solve !! switching to dense solver\n");
@@ -74,9 +72,10 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
                     "[SolveLinearSystem] Cholesky Decomposition Failed "
                     "!! switching to dense solver\n");
         }
+    } else {
+        x = A.ldlt().solve(b);
     }
 
-    x = A.ldlt().solve(b);
     return std::make_tuple(true, std::move(x));
 }
 

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -64,20 +64,18 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
         A_chol.compute(A_sparse);
         if (A_chol.info() == Eigen::Success) {
             x = A_chol.solve(b);
-            if (A_chol.info() != Eigen::Success) {
-                PrintInfo(
-                        "[SolveLinearSystemPSD] sparse solver couldn't "
-                        "solve !! switching to dense solver\n");
+            if (A_chol.info() == Eigen::Success) {
+                // Both decompose and solve are successful
+                return std::make_tuple(true, std::move(x));
+            } else {
+                PrintInfo("Cholesky solve failed, switched to dense solver\n");
             }
         } else {
-            PrintInfo(
-                    "[SolveLinearSystemPSD] Cholesky Decomposition Failed "
-                    "!! switching to dense solver\n");
+            PrintInfo("Cholesky decompose failed, switched to dense solver\n");
         }
-    } else {
-        x = A.ldlt().solve(b);
     }
 
+    x = A.ldlt().solve(b);
     return std::make_tuple(true, std::move(x));
 }
 

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -37,21 +37,13 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
         const Eigen::VectorXd &b,
         bool check_det /* = true */) {
     if (check_det) {
-        bool solution_exist = true;
         double det = A.determinant();
-        if (fabs(det) < 1e-6 || std::isnan(det) || std::isinf(det))
-            solution_exist = false;
-        if (solution_exist) {
-            // Robust Cholesky decomposition of a matrix with pivoting.
-            Eigen::MatrixXd x = A.ldlt().solve(b);
-            return std::make_tuple(solution_exist, std::move(x));
-        } else {
+        if (fabs(det) < 1e-6 || std::isnan(det) || std::isinf(det)) {
             return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
         }
-    } else {
-        Eigen::MatrixXd x = A.ldlt().solve(b);
-        return std::make_tuple(true, std::move(x));
     }
+    Eigen::MatrixXd x = A.ldlt().solve(b);
+    return std::make_tuple(true, std::move(x));
 }
 
 Eigen::Matrix4d TransformVector6dToMatrix4d(const Eigen::Vector6d &input) {

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -33,7 +33,7 @@
 namespace open3d {
 
 /// Function to solve Ax=b
-std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
+std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
         const Eigen::MatrixXd &A,
         const Eigen::VectorXd &b,
         bool prefer_sparse /* = false */,
@@ -66,12 +66,12 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
             x = A_chol.solve(b);
             if (A_chol.info() != Eigen::Success) {
                 PrintInfo(
-                        "[SolveLinearSystem] sparse solver couldn't "
+                        "[SolveLinearSystemPSD] sparse solver couldn't "
                         "solve !! switching to dense solver\n");
             }
         } else {
             PrintInfo(
-                    "[SolveLinearSystem] Cholesky Decomposition Failed "
+                    "[SolveLinearSystemPSD] Cholesky Decomposition Failed "
                     "!! switching to dense solver\n");
         }
     } else {
@@ -117,7 +117,7 @@ std::tuple<bool, Eigen::Matrix4d> SolveJacobianSystemAndObtainExtrinsicMatrix(
 
     bool solution_exist;
     Eigen::Vector6d x;
-    std::tie(solution_exist, x) = SolveLinearSystem(JTJ, -JTr);
+    std::tie(solution_exist, x) = SolveLinearSystemPSD(JTJ, -JTr);
 
     if (solution_exist) {
         Eigen::Matrix4d extrinsic = TransformVector6dToMatrix4d(x);
@@ -141,7 +141,7 @@ SolveJacobianSystemAndObtainExtrinsicMatrixArray(const Eigen::MatrixXd &JTJ,
 
     bool solution_exist;
     Eigen::VectorXd x;
-    std::tie(solution_exist, x) = SolveLinearSystem(JTJ, JTr);
+    std::tie(solution_exist, x) = SolveLinearSystemPSD(JTJ, JTr);
 
     if (solution_exist) {
         int nposes = (int)x.rows() / 6;

--- a/src/Core/Utility/Eigen.cpp
+++ b/src/Core/Utility/Eigen.cpp
@@ -46,6 +46,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(
         }
     }
 
+    // Check PSD: https://stackoverflow.com/a/54569657/1255535
     if (check_psd) {
         Eigen::LLT<Eigen::MatrixXd> A_llt(A);
         if (!A.isApprox(A.transpose()) ||

--- a/src/Core/Utility/Eigen.h
+++ b/src/Core/Utility/Eigen.h
@@ -65,11 +65,12 @@ Eigen::Matrix4d TransformVector6dToMatrix4d(const Eigen::Vector6d &input);
 Eigen::Vector6d TransformMatrix4dToVector6d(const Eigen::Matrix4d &input);
 
 /// Function to solve Ax=b
-std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(const Eigen::MatrixXd &A,
-                                                    const Eigen::VectorXd &b,
-                                                    bool prefer_sparse = false,
-                                                    bool check_det = false,
-                                                    bool check_psd = false);
+std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
+        const Eigen::MatrixXd &A,
+        const Eigen::VectorXd &b,
+        bool prefer_sparse = false,
+        bool check_det = false,
+        bool check_psd = false);
 
 /// Function to solve Jacobian system
 /// Input: 6x6 Jacobian matrix and 6-dim residual vector.

--- a/src/Core/Utility/Eigen.h
+++ b/src/Core/Utility/Eigen.h
@@ -67,8 +67,9 @@ Eigen::Vector6d TransformMatrix4dToVector6d(const Eigen::Matrix4d &input);
 /// Function to solve Ax=b
 std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(const Eigen::MatrixXd &A,
                                                     const Eigen::VectorXd &b,
-                                                    bool check_det = true,
-                                                    bool prefer_sparse = false);
+                                                    bool prefer_sparse = false,
+                                                    bool check_det = false,
+                                                    bool check_psd = false);
 
 /// Function to solve Jacobian system
 /// Input: 6x6 Jacobian matrix and 6-dim residual vector.

--- a/src/Core/Utility/Eigen.h
+++ b/src/Core/Utility/Eigen.h
@@ -67,7 +67,8 @@ Eigen::Vector6d TransformMatrix4dToVector6d(const Eigen::Matrix4d &input);
 /// Function to solve Ax=b
 std::tuple<bool, Eigen::VectorXd> SolveLinearSystem(const Eigen::MatrixXd &A,
                                                     const Eigen::VectorXd &b,
-                                                    bool check_det = true);
+                                                    bool check_det = true,
+                                                    bool prefer_sparse = false);
 
 /// Function to solve Jacobian system
 /// Input: 6x6 Jacobian matrix and 6-dim residual vector.

--- a/src/UnitTest/Core/Utility/Eigen.cpp
+++ b/src/UnitTest/Core/Utility/Eigen.cpp
@@ -71,7 +71,7 @@ TEST(Eigen, TransformMatrix4dToVector6d) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Eigen, SolveLinearSystem) {
+TEST(Eigen, SolveLinearSystemPSD) {
     Matrix3d A;
     Vector3d b;
     Vector3d x;
@@ -82,9 +82,9 @@ TEST(Eigen, SolveLinearSystem) {
     A << 3, 2, 1, 30, 20, 10, -1, 0.5, -1;
     b << 1, -2, 0;
     x_ref << 0, 0, 0;
-    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
-                                       /*check_det=*/true,
-                                       /*check_psd=*/false);
+    tie(status, x) = SolveLinearSystemPSD(A, b, /*prefer_sparse=*/false,
+                                          /*check_det=*/true,
+                                          /*check_psd=*/false);
     EXPECT_EQ(status, false);
     ExpectEQ(x, x_ref);
 
@@ -92,9 +92,9 @@ TEST(Eigen, SolveLinearSystem) {
     A << 3, 2, -1, 2, -2, 4, -1, 0.5, -1;
     b << 1, -2, 0;
     x_ref << 0, 0, 0;
-    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
-                                       /*check_det=*/false,
-                                       /*check_psd=*/true);
+    tie(status, x) = SolveLinearSystemPSD(A, b, /*prefer_sparse=*/false,
+                                          /*check_det=*/false,
+                                          /*check_psd=*/true);
     EXPECT_EQ(status, false);
     ExpectEQ(x, x_ref);
 
@@ -103,8 +103,9 @@ TEST(Eigen, SolveLinearSystem) {
     A << 3, 2, 1, 2, 3, 1, 1, 2, 3;
     b << 39, 34, 26;
     x_ref << 0, 0, 0;  // 9.25, 4.25, 2.75 if solved in general form
-    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
-                                       /*check_det=*/false, /*check_psd=*/true);
+    tie(status, x) =
+            SolveLinearSystemPSD(A, b, /*prefer_sparse=*/false,
+                                 /*check_det=*/false, /*check_psd=*/true);
     EXPECT_EQ(status, false);
     ExpectEQ(x, x_ref);
 
@@ -112,14 +113,16 @@ TEST(Eigen, SolveLinearSystem) {
     A << 3, 0, 1, 0, 3, 0, 1, 0, 3;
     b << 18, 15, 22;
     x_ref << 4, 5, 6;
-    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
-                                       /*check_det=*/true, /*check_psd=*/true);
+    tie(status, x) =
+            SolveLinearSystemPSD(A, b, /*prefer_sparse=*/false,
+                                 /*check_det=*/true, /*check_psd=*/true);
     EXPECT_EQ(status, true);
     ExpectEQ(x, x_ref);
 
     // The sparse solver shall work in as well
-    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/true,
-                                       /*check_det=*/true, /*check_psd=*/true);
+    tie(status, x) =
+            SolveLinearSystemPSD(A, b, /*prefer_sparse=*/true,
+                                 /*check_det=*/true, /*check_psd=*/true);
     EXPECT_EQ(status, true);
     ExpectEQ(x, x_ref);
 }

--- a/src/UnitTest/Core/Utility/Eigen.cpp
+++ b/src/UnitTest/Core/Utility/Eigen.cpp
@@ -99,7 +99,6 @@ TEST(Eigen, SolveLinearSystem) {
     ExpectEQ(x, x_ref);
 
     // Rank == 3, "fake PSD" (eigen values >= 0 and full rank but not symmetric)
-    // https://stackoverflow.com/a/54569657/1255535
     // check_psd == true, should return error
     A << 3, 2, 1, 2, 3, 1, 1, 2, 3;
     b << 39, 34, 26;

--- a/src/UnitTest/Core/Utility/Eigen.cpp
+++ b/src/UnitTest/Core/Utility/Eigen.cpp
@@ -99,14 +99,29 @@ TEST(Eigen, SolveLinearSystem) {
     ExpectEQ(x, x_ref);
 
     // Rank == 3, "fake PSD" (eigen values >= 0 and full rank but not symmetric)
+    // https://stackoverflow.com/a/54569657/1255535
     // check_psd == true, should return error
-    // Numbers from: "The Nine Chapters on the Mathematical Art", Chapter 8
     A << 3, 2, 1, 2, 3, 1, 1, 2, 3;
     b << 39, 34, 26;
     x_ref << 0, 0, 0;  // 9.25, 4.25, 2.75 if solved in general form
     tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
                                        /*check_det=*/false, /*check_psd=*/true);
     EXPECT_EQ(status, false);
+    ExpectEQ(x, x_ref);
+
+    // A regular PSD case
+    A << 3, 0, 1, 0, 3, 0, 1, 0, 3;
+    b << 18, 15, 22;
+    x_ref << 4, 5, 6;
+    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
+                                       /*check_det=*/true, /*check_psd=*/true);
+    EXPECT_EQ(status, true);
+    ExpectEQ(x, x_ref);
+
+    // The sparse solver shall work in as well
+    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/true,
+                                       /*check_det=*/true, /*check_psd=*/true);
+    EXPECT_EQ(status, true);
     ExpectEQ(x, x_ref);
 }
 

--- a/src/UnitTest/Core/Utility/Eigen.cpp
+++ b/src/UnitTest/Core/Utility/Eigen.cpp
@@ -99,8 +99,8 @@ TEST(Eigen, SolveLinearSystem) {
     ExpectEQ(x, x_ref);
 
     // Rank == 3, "fake PSD" (eigen values >= 0 and full rank but not symmetric)
-    // Numbers taken from: The Nine Chapters on the Mathematical Art, Chapter 8
-    // This shall be solvable in the general form, but not for Eigen's ldlt
+    // check_psd == true, should return error
+    // Numbers from: "The Nine Chapters on the Mathematical Art", Chapter 8
     A << 3, 2, 1, 2, 3, 1, 1, 2, 3;
     b << 39, 34, 26;
     x_ref << 0, 0, 0;  // 9.25, 4.25, 2.75 if solved in general form

--- a/src/UnitTest/Core/Utility/Eigen.cpp
+++ b/src/UnitTest/Core/Utility/Eigen.cpp
@@ -72,28 +72,52 @@ TEST(Eigen, TransformMatrix4dToVector6d) {
 //
 // ----------------------------------------------------------------------------
 TEST(Eigen, SolveLinearSystem) {
-    Matrix4d A = Matrix4d::Random();
-
-    // make sure A is positive semi-definite
-    A = A.transpose() * A;
-
-    // make sure det(A) != 0
-    A = A + Matrix4d::Identity();
-
+    Matrix3d A;
+    Vector3d b;
+    Vector3d x;
+    Vector3d x_ref;
     bool status = false;
-    Vector4d result;
 
-    int loops = 10000;
-    srand((unsigned int)time(0));
-    for (int i = 0; i < loops; i++) {
-        Vector4d x = Vector4d::Random();
+    // Rank == 2, check_det == true, should return error
+    A << 3, 2, 1, 30, 20, 10, -1, 0.5, -1;
+    b << 1, -2, 0;
+    x_ref << 0, 0, 0;
+    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
+                                       /*check_det=*/true, /*check_psd=*/false);
+    EXPECT_EQ(status, false);
+    ExpectEQ(x, x_ref);
 
-        Vector4d b = A * x;
+    // Rank == 3, not PSD, check_psd == true, should return error
+    A << 3, 2, -1, 2, -2, 4, -1, 0.5, -1;
+    b << 1, -2, 0;
+    x_ref << 0, 0, 0;
+    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
+                                       /*check_det=*/false, /*check_psd=*/true);
+    EXPECT_EQ(status, false);
+    ExpectEQ(x, x_ref);
 
-        tie(status, result) = SolveLinearSystem(A, b);
+    // Matrix4d A = Matrix4d::Random();
 
-        ExpectEQ(result, x);
-    }
+    // // make sure A is positive semi-definite
+    // A = A.transpose() * A;
+
+    // // make sure det(A) != 0
+    // A = A + Matrix4d::Identity();
+
+    // bool status = false;
+    // Vector4d result;
+
+    // int loops = 10000;
+    // srand((unsigned int)time(0));
+    // for (int i = 0; i < loops; i++) {
+    //     Vector4d x = Vector4d::Random();
+
+    //     Vector4d b = A * x;
+
+    //     tie(status, result) = SolveLinearSystem(A, b);
+
+    //     ExpectEQ(result, x);
+    // }
 }
 
 // ----------------------------------------------------------------------------

--- a/src/UnitTest/Core/Utility/Eigen.cpp
+++ b/src/UnitTest/Core/Utility/Eigen.cpp
@@ -83,7 +83,8 @@ TEST(Eigen, SolveLinearSystem) {
     b << 1, -2, 0;
     x_ref << 0, 0, 0;
     tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
-                                       /*check_det=*/true, /*check_psd=*/false);
+                                       /*check_det=*/true,
+                                       /*check_psd=*/false);
     EXPECT_EQ(status, false);
     ExpectEQ(x, x_ref);
 
@@ -92,32 +93,21 @@ TEST(Eigen, SolveLinearSystem) {
     b << 1, -2, 0;
     x_ref << 0, 0, 0;
     tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
-                                       /*check_det=*/false, /*check_psd=*/true);
+                                       /*check_det=*/false,
+                                       /*check_psd=*/true);
     EXPECT_EQ(status, false);
     ExpectEQ(x, x_ref);
 
-    // Matrix4d A = Matrix4d::Random();
-
-    // // make sure A is positive semi-definite
-    // A = A.transpose() * A;
-
-    // // make sure det(A) != 0
-    // A = A + Matrix4d::Identity();
-
-    // bool status = false;
-    // Vector4d result;
-
-    // int loops = 10000;
-    // srand((unsigned int)time(0));
-    // for (int i = 0; i < loops; i++) {
-    //     Vector4d x = Vector4d::Random();
-
-    //     Vector4d b = A * x;
-
-    //     tie(status, result) = SolveLinearSystem(A, b);
-
-    //     ExpectEQ(result, x);
-    // }
+    // Rank == 3, "fake PSD" (eigen values >= 0 and full rank but not symmetric)
+    // Numbers taken from: The Nine Chapters on the Mathematical Art, Chapter 8
+    // This shall be solvable in the general form, but not for Eigen's ldlt
+    A << 3, 2, 1, 2, 3, 1, 1, 2, 3;
+    b << 39, 34, 26;
+    x_ref << 0, 0, 0;  // 9.25, 4.25, 2.75 if solved in general form
+    tie(status, x) = SolveLinearSystem(A, b, /*prefer_sparse=*/false,
+                                       /*check_det=*/false, /*check_psd=*/true);
+    EXPECT_EQ(status, false);
+    ExpectEQ(x, x_ref);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR contains only interface changes, numerical values of the algorithms stay the same.

- Rename to `SolveLinearSystemPSD`
- Optional `check_det` checks if the matrix is valid and full rank, otherwise it returns zero matrix
- Optional `check_psd` checks if the matrix is positive-semidefinite, otherwise the function SolveLinearSystemPSD cannot solve this matrix and return zero
- Without specification, the `SolveLinearSystemPSD` assumes the input matrix is PSD and bypass these two checks