### PR TITLE
Compute vertex adjacency map

### DIFF
--- a/src/Core/Geometry/TriangleMesh.cpp
+++ b/src/Core/Geometry/TriangleMesh.cpp
@@ -185,6 +185,18 @@ void TriangleMesh::ComputeVertexNormals(bool normalized /* = true*/) {
     }
 }
 
+void TriangleMesh::ComputeAdjacencyList() {
+    adjacency_list_.resize(vertices_.size());
+    for (const auto &triangle : triangles_) {
+        adjacency_list_[triangle(0)].insert(triangle(1));
+        adjacency_list_[triangle(0)].insert(triangle(2));
+        adjacency_list_[triangle(1)].insert(triangle(0));
+        adjacency_list_[triangle(1)].insert(triangle(2));
+        adjacency_list_[triangle(2)].insert(triangle(0));
+        adjacency_list_[triangle(2)].insert(triangle(1));
+    }
+}
+
 void TriangleMesh::Purge() {
     RemoveDuplicatedVertices();
     RemoveDuplicatedTriangles();

--- a/src/Core/Geometry/TriangleMesh.h
+++ b/src/Core/Geometry/TriangleMesh.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <vector>
+#include <unordered_set>
 #include <memory>
 #include <Eigen/Core>
 
@@ -55,6 +56,9 @@ public:
 
     /// Function to compute vertex normals, usually called before rendering
     void ComputeVertexNormals(bool normalized = true);
+
+    /// Function to compute adjacency list, call before adjacency list is needed
+    void ComputeAdjacencyList();
 
     /// Function to remove duplicated and non-manifold vertices/triangles
     void Purge();
@@ -86,6 +90,11 @@ public:
         return HasTriangles() && triangles_.size() == triangle_normals_.size();
     }
 
+    bool HasAdjacencyList() const {
+        return vertices_.size() > 0 &&
+               adjacency_list_.size() == vertices_.size();
+    }
+
     void NormalizeNormals() {
         for (size_t i = 0; i < vertex_normals_.size(); i++) {
             vertex_normals_[i].normalize();
@@ -114,6 +123,7 @@ public:
     std::vector<Eigen::Vector3d> vertex_colors_;
     std::vector<Eigen::Vector3i> triangles_;
     std::vector<Eigen::Vector3d> triangle_normals_;
+    std::vector<std::unordered_set<int>> adjacency_list_;
 };
 
 /// Function to select points from \param input TriangleMesh into

--- a/src/Python/Core/open3d_trianglemesh.cpp
+++ b/src/Python/Core/open3d_trianglemesh.cpp
@@ -57,6 +57,9 @@ void pybind_trianglemesh(py::module &m) {
                  "Function to compute vertex normals, usually called before "
                  "rendering",
                  "normalized"_a = true)
+            .def("compute_adjacency_list", &TriangleMesh::ComputeAdjacencyList,
+                 "Function to compute adjacency list, call before adjacency "
+                 "list is needed")
             .def("purge", &TriangleMesh::Purge,
                  "Function to remove duplicated and non-manifold "
                  "vertices/triangles")
@@ -65,6 +68,7 @@ void pybind_trianglemesh(py::module &m) {
             .def("has_vertex_normals", &TriangleMesh::HasVertexNormals)
             .def("has_vertex_colors", &TriangleMesh::HasVertexColors)
             .def("has_triangle_normals", &TriangleMesh::HasTriangleNormals)
+            .def("has_adjacency_list", &TriangleMesh::HasAdjacencyList)
             .def("normalize_normals", &TriangleMesh::NormalizeNormals)
             .def("paint_uniform_color", &TriangleMesh::PaintUniformColor)
             .def_readwrite("vertices", &TriangleMesh::vertices_)

--- a/src/Python/Core/open3d_trianglemesh.cpp
+++ b/src/Python/Core/open3d_trianglemesh.cpp
@@ -75,8 +75,8 @@ void pybind_trianglemesh(py::module &m) {
             .def_readwrite("vertex_normals", &TriangleMesh::vertex_normals_)
             .def_readwrite("vertex_colors", &TriangleMesh::vertex_colors_)
             .def_readwrite("triangles", &TriangleMesh::triangles_)
-            .def_readwrite("triangle_normals",
-                           &TriangleMesh::triangle_normals_);
+            .def_readwrite("triangle_normals", &TriangleMesh::triangle_normals_)
+            .def_readwrite("adjacency_list", &TriangleMesh::adjacency_list_);
 }
 
 void pybind_trianglemesh_methods(py::module &m) {

--- a/src/UnitTest/Core/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Core/Geometry/TriangleMesh.cpp
@@ -485,6 +485,40 @@ TEST(TriangleMesh, ComputeVertexNormals) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
+TEST(TriangleMesh, ComputeAdjacencyList) {
+    // 4-sided pyramid with A as top vertex, bottom has two triangles
+    Eigen::Vector3d A(0, 0, 1);    // 0
+    Eigen::Vector3d B(1, 1, 0);    // 1
+    Eigen::Vector3d C(-1, 1, 0);   // 2
+    Eigen::Vector3d D(-1, -1, 0);  // 3
+    Eigen::Vector3d E(1, -1, 0);   // 4
+    std::vector<Eigen::Vector3d> vertices{A, B, C, D, E};
+
+    TriangleMesh tm;
+    tm.vertices_.insert(tm.vertices_.end(), std::begin(vertices),
+                        std::end(vertices));
+    tm.triangles_ = {Eigen::Vector3i(0, 1, 2), Eigen::Vector3i(0, 2, 3),
+                     Eigen::Vector3i(0, 3, 4), Eigen::Vector3i(0, 4, 1),
+                     Eigen::Vector3i(1, 2, 4), Eigen::Vector3i(2, 3, 4)};
+    EXPECT_FALSE(tm.HasAdjacencyList());
+    tm.ComputeAdjacencyList();
+    EXPECT_TRUE(tm.HasAdjacencyList());
+
+    // A
+    EXPECT_TRUE(tm.adjacency_list_[0] == std::unordered_set<int>({1, 2, 3, 4}));
+    // B
+    EXPECT_TRUE(tm.adjacency_list_[1] == std::unordered_set<int>({0, 2, 4}));
+    // C
+    EXPECT_TRUE(tm.adjacency_list_[2] == std::unordered_set<int>({0, 1, 3, 4}));
+    // D
+    EXPECT_TRUE(tm.adjacency_list_[3] == std::unordered_set<int>({0, 2, 4}));
+    // E
+    EXPECT_TRUE(tm.adjacency_list_[4] == std::unordered_set<int>({0, 1, 2, 3}));
+}
+
+// ----------------------------------------------------------------------------
+//
+// ----------------------------------------------------------------------------
 TEST(TriangleMesh, Purge) {
     vector<Vector3d> ref_vertices = {{839.215686, 392.156863, 780.392157},
                                      {796.078431, 909.803922, 196.078431},


### PR DESCRIPTION
Adjacency map is useful for implementing some mesh operations. There are some decision made with Jaesik. Please feel free to comment on the datastructure selection. 

1. map vs vector vs set
    ```cpp
    std::vector<std::unordered_set<int>> // selected, to fast check if two nodes are neighbors
    std::vector<int, std::vector<int>>
    std::unordered_map<int, std::unordered_set<int>>
    ```
2. size_t vs int
    ```cpp
    std::vector<std::unordered_set<int>> // selected
    std::vector<std::unordered_set<size_t>>
    ```

Tested with python as well
```python
type(mesh.adjacency_list[0])
Out[4]: set
type(mesh.adjacency_list)
Out[5]: list
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/830)
<!-- Reviewable:end -->
