### PR TITLE
Iteration number from RANSAC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # config options
 option(BUILD_SHARED_LIBS         "Build shared libraries"                   OFF)
-option(WITH_OPENMP               "Use OpenMP multi-threading"               ON)
+option(WITH_OPENMP               "Use OpenMP multi-threading"               OFF)
 option(ENABLE_HEADLESS_RENDERING "Use OSMesa for headless rendering"        OFF)
 option(BUILD_CPP_EXAMPLES        "Build the Open3D example programs"        ON)
 option(BUILD_UNIT_TESTS          "Build the Open3D unit tests"              OFF)

--- a/src/Open3D/Registration/Registration.cpp
+++ b/src/Open3D/Registration/Registration.cpp
@@ -191,6 +191,7 @@ RegistrationResult RegistrationICP(
                     criteria.relative_fitness_ &&
             std::abs(backup.inlier_rmse_ - result.inlier_rmse_) <
                     criteria.relative_rmse_) {
+            result.iteration_number_ = i;
             break;
         }
     }
@@ -232,10 +233,11 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
             (this_result.fitness_ == result.fitness_ &&
              this_result.inlier_rmse_ < result.inlier_rmse_)) {
             result = this_result;
+            result.iteration_number_ = itr;
         }
     }
-    utility::PrintDebug("RANSAC: Fitness %.4f, RMSE %.4f\n", result.fitness_,
-                        result.inlier_rmse_);
+    utility::PrintDebug("RANSAC: Iteration %d, Fitness %.4f, RMSE %.4f\n",
+            result.iteration_number_, result.fitness_, result.inlier_rmse_);
     return result;
 }
 
@@ -341,6 +343,7 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
                     (this_result.fitness_ == result_private.fitness_ &&
                      this_result.inlier_rmse_ < result_private.inlier_rmse_)) {
                     result_private = this_result;
+                    result_private.iteration_number_ = itr;
                 }
 #ifdef _OPENMP
 #pragma omp critical
@@ -366,8 +369,8 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
     }
 #endif
     utility::PrintDebug("total_validation : %d\n", total_validation);
-    utility::PrintDebug("RANSAC: Fitness %.4f, RMSE %.4f\n", result.fitness_,
-                        result.inlier_rmse_);
+    utility::PrintDebug("RANSAC: Iteration %d, Fitness %.4f, RMSE %.4f\n",
+                        result.iteration_number_, result.fitness_, result.inlier_rmse_);
     return result;
 }
 

--- a/src/Open3D/Registration/Registration.h
+++ b/src/Open3D/Registration/Registration.h
@@ -86,7 +86,7 @@ class RegistrationResult {
 public:
     RegistrationResult(
             const Eigen::Matrix4d &transformation = Eigen::Matrix4d::Identity())
-        : transformation_(transformation), inlier_rmse_(0.0), fitness_(0.0) {}
+        : transformation_(transformation), inlier_rmse_(0.0), fitness_(0.0), iteration_number_(0) {}
     ~RegistrationResult() {}
 
 public:
@@ -94,6 +94,7 @@ public:
     CorrespondenceSet correspondence_set_;
     double inlier_rmse_;
     double fitness_;
+    int iteration_number_;
 };
 
 /// Function for evaluation

--- a/src/Python/registration/registration.cpp
+++ b/src/Python/registration/registration.cpp
@@ -351,10 +351,14 @@ void pybind_registration_classes(py::module &m) {
                            &registration::RegistrationResult::inlier_rmse_)
             .def_readwrite("fitness",
                            &registration::RegistrationResult::fitness_)
+            .def_readwrite("iteration_number",
+                           &registration::RegistrationResult::iteration_number_)
             .def("__repr__", [](const registration::RegistrationResult &rr) {
                 return std::string(
-                               "registration::RegistrationResult with fitness "
+                               "registration::RegistrationResult with iteration number "
                                "= ") +
+                       std::to_string(rr.iteration_number_) +
+                       std::string(", fitness = ") +
                        std::to_string(rr.fitness_) +
                        std::string(", inlier_rmse = ") +
                        std::to_string(rr.inlier_rmse_) +


### PR DESCRIPTION
Current RANSAC family functions does not provide number of iterations after RANSAC finishes.
Extending RegistrationResult class a bit to convey iteration numbers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/876)
<!-- Reviewable:end -->
