### PR TITLE
Reorganize readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,37 @@
 
 # Open3D: A Modern Library for 3D Data Processing
 
-[![Build Status](https://travis-ci.org/IntelVCL/Open3D.svg?branch=master)](https://travis-ci.org/IntelVCL/Open3D)
-[![Build status](https://ci.appveyor.com/api/projects/status/sau3yewsyxaxpkqe?svg=true)](https://ci.appveyor.com/project/syncle/open3d)
-
-## About this project
+<h4>
+    <a href="http://www.open3d.org">open3d.org</a> |
+    <a href="http://www.open3d.org/docs">Documentation</a> |
+    <a href="http://open3d.org/docs/getting_started.html">Quick Start</a> |
+    <a href="http://www.open3d.org/docs/compilation.html">Build from Source</a> |
+    <a href="http://www.open3d.org/docs/index.html#python-api-index">Python API</a> |
+    <a href="http://open3d.org/cppapi/index.html">C++ API</a> |
+    <a href="https://www.youtube.com/watch?v=I3UjXlA4IsU">Demo</a> |
+    <a href="http://www.open3d.org/docs/contribute.html">Contribute</a>
+</h4>
 
 Open3D is an open-source library that supports rapid development of software that deals with 3D data. The Open3D frontend exposes a set of carefully selected data structures and algorithms in both C++ and Python. The backend is highly optimized and is set up for parallelization. We welcome contributions from the open-source community.
 
-Please cite our work if you use Open3D.
+## Core features
+
+* 3D data structures
+* 3D data processing algorithms
+* Scene reconstruction
+* Surface alignment
+* 3D visualization
+* Python binding
+
+## Supported OSes and compilers
+
+* Ubuntu 16.04 or later: GCC 4.9 or later [![Build Status](https://travis-ci.org/IntelVCL/Open3D.svg?branch=master)](https://travis-ci.org/IntelVCL/Open3D)
+* macOS: XCode 8.0 or later [![Build Status](https://travis-ci.org/IntelVCL/Open3D.svg?branch=master)](https://travis-ci.org/IntelVCL/Open3D)
+* Windows: Visual Studio 2015 update 3 or later [![Build status](https://ci.appveyor.com/api/projects/status/sau3yewsyxaxpkqe?svg=true)](https://ci.appveyor.com/project/syncle/open3d)
+
+## Citation
+Please cite [our work](https://arxiv.org/abs/1801.09847) if you use Open3D.
+
 ```
 @article{Zhou2018,
 	author    = {Qian-Yi Zhou and Jaesik Park and Vladlen Koltun},
@@ -21,31 +44,7 @@ Please cite our work if you use Open3D.
 }
 ```
 
-## Core features
-
-* Basic 3D data structures
-* Basic 3D data processing algorithms
-* Scene reconstruction
-* Surface alignment
-* 3D visualization
-* Python binding
-
-## Supported compilers
-
-* GCC 4.8 and later on Linux
-* XCode 8.0 and later on OS X
-* Visual Studio 2015 update 3 and later on Windows
-
-## Open3D ecosystem
+## Ecosystem
 
 * [Open3D-PointNet:](https://github.com/IntelVCL/Open3D-PointNet) A fork of PyTorch PointNet for point cloud classification and semantic segmentation compatible with Open3D.
 * [Open3D-PointNet++:](https://github.com/IntelVCL/Open3D-PointNet2-Semantic3D) A re-implementation of PointNet++ using Open3D to enable real-time semantic segmentation of LIDAR point clouds.
-
-
-## Resources
-
-* Website: [open3d.org](http://www.open3d.org)
-* Code: [github.com/IntelVCL/Open3D](https://github.com/IntelVCL/Open3D)
-* Document: [open3d.org/docs](http://www.open3d.org/docs)
-* Getting started: [open3d.org/docs/getting_started.html](http://open3d.org/docs/getting_started.html)
-* License: [The MIT license](https://opensource.org/licenses/MIT)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,8 @@ Open3D: A Modern Library for 3D Data Processing
     tutorial/docker/index
     tutorial/reference
 
+.. _python_api_index:
+
 .. toctree::
     :maxdepth: 1
     :caption: Python API


### PR DESCRIPTION
- Move links to very front and simplify readme. 
- Move citation to a separate section.

Preview of how it looks:
https://github.com/yxlao/Open3D/blob/readme-reorg/README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/887)
<!-- Reviewable:end -->
